### PR TITLE
Github integration in RTD theme (resolves #72)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,15 @@ html_theme = 'sphinx_rtd_theme'
 #
 # html_theme_options = {}
 
+# HTML context adapted from http://docs.readthedocs.io/en/latest/vcs.html
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "wright-group", # Username
+    "github_repo": "WrightTools", # Repo name
+    "github_version": "documentation", # Version
+    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
Currently points to the documentation branch is this expected behaviour?