### PR TITLE
wintemp

### DIFF
--- a/WrightTools/_base.py
+++ b/WrightTools/_base.py
@@ -76,6 +76,8 @@ class Group(h5py.Group):
         if not edit_local:
             tmpfile = tempfile.NamedTemporaryFile(prefix='', suffix='.wt5')
             p = tmpfile.name
+        self.__class__.instances.pop(self.fullpath)
+            tmpfile.close()
             if filepath:
                 shutil.copyfile(src=filepath, dst=p)
         elif edit_local and filepath:

--- a/WrightTools/_base.py
+++ b/WrightTools/_base.py
@@ -5,6 +5,7 @@
 
 
 import shutil
+import os
 import weakref
 import tempfile
 import posixpath
@@ -74,9 +75,8 @@ class Group(h5py.Group):
         if edit_local and filepath is None:
             raise Exception  # TODO: better exception
         if not edit_local:
-            tmpfile = tempfile.NamedTemporaryFile(prefix='', suffix='.wt5')
-            p = tmpfile.name
-            tmpfile.close()
+            tmpfile = tempfile.mkstemp(prefix='', suffix='.wt5')
+            p = tmpfile[1]
             if filepath:
                 shutil.copyfile(src=filepath, dst=p)
         elif edit_local and filepath:
@@ -95,7 +95,7 @@ class Group(h5py.Group):
             cls.__init__(instance, **kwargs)
             cls.instances[fullpath] = instance
             if tmpfile:
-                setattr(instance, '_tmpfile', tmpfile)
+                setattr(instance, '_tmpfile', tmpfile[1])
                 weakref.finalize(instance, instance.close)
             return instance
         instance = cls.instances[fullpath]
@@ -138,7 +138,7 @@ class Group(h5py.Group):
             self.file.flush()
             self.file.close()
             if hasattr(self, '_tmpfile'):
-                self._tmpfile.close()
+                os.remove(self._tmpfile)
 
     def flush(self):
         self.file.flush()

--- a/WrightTools/_base.py
+++ b/WrightTools/_base.py
@@ -76,7 +76,6 @@ class Group(h5py.Group):
         if not edit_local:
             tmpfile = tempfile.NamedTemporaryFile(prefix='', suffix='.wt5')
             p = tmpfile.name
-        self.__class__.instances.pop(self.fullpath)
             tmpfile.close()
             if filepath:
                 shutil.copyfile(src=filepath, dst=p)

--- a/WrightTools/_base.py
+++ b/WrightTools/_base.py
@@ -95,7 +95,7 @@ class Group(h5py.Group):
             cls.__init__(instance, **kwargs)
             cls.instances[fullpath] = instance
             if tmpfile:
-                setattr(instance, '_tmpfile', tmpfile[1])
+                setattr(instance, '_tmpfile', tmpfile)
                 weakref.finalize(instance, instance.close)
             return instance
         instance = cls.instances[fullpath]
@@ -138,7 +138,8 @@ class Group(h5py.Group):
             self.file.flush()
             self.file.close()
             if hasattr(self, '_tmpfile'):
-                os.remove(self._tmpfile)
+                os.close(self._tmpfile[0])
+                os.remove(self._tmpfile[1])
 
     def flush(self):
         self.file.flush()


### PR DESCRIPTION
This solution feels mildly fragile, as technically the name is available to be allocated again by NamedTemporaryFile, but windows does not allow you to open a temp file while the one created is still open. Closing resolves that issue, and the tests seem to pass.