### PR TITLE
Collections next return key, rather than value (Closes #350)

### DIFF
--- a/WrightTools/collection/_collection.py
+++ b/WrightTools/collection/_collection.py
@@ -37,7 +37,7 @@ class Collection(Group):
 
     def __next__(self):
         if self.__n < len(self):
-            out = self[self.__n]
+            out = self.item_names[self.__n]
             self.__n += 1
         else:
             raise StopIteration


### PR DESCRIPTION
Note, this changes what `__next__` returns from the objects to their keys

This makes `.keys()` and `.items()` work, at the expense of having to use `__getitem__` within loops. This is, however, consistent with how h5py works.