### PR TITLE
copy and save

### DIFF
--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -226,6 +226,7 @@ class Group(h5py.Group):
         if name is None:
             name = self.natural_name
         if parent is None:
+            from ._open import open as wt_open  # circular import
             new = Group()  # root of new tempfile
             # attrs
             new.attrs.update(self.attrs)
@@ -235,7 +236,6 @@ class Group(h5py.Group):
                 self[k].copy(new)
             new.flush()
             p = new.filepath
-            from ._open import open as wt_open
             new = wt_open(p)
         else:
             # copy

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -230,6 +230,10 @@ class Group(h5py.Group):
             # children
             for k in self.keys():
                 self[k].copy(new)
+            new.flush()
+            p = new.filepath
+            from ._open import open as wt_open
+            new = wt_open(p)
         else:
             # copy
             self.file.copy(self.name, parent, name=name)
@@ -269,7 +273,7 @@ class Group(h5py.Group):
             filepath += '.wt5'
         filepath = os.path.expanduser(filepath)
         # copy to new file
-        f = h5py.File(filepath)
+        h5py.File(filepath)
         new = Group(filepath=filepath)
         # attrs
         for k, v in self.attrs.items():

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -191,7 +191,7 @@ class Group(h5py.Group):
             try:
                 self.file.flush()
                 self.file.close()
-            except:
+            except SystemError:
                 pass
             finally:
                 if hasattr(self, '_tmpfile'):

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -65,6 +65,7 @@ class Group(h5py.Group):
         for name in self.item_names:
             self._items.append(self[name])
             setattr(self, name, self[name])
+        self._update_natural_namespace()
         # the following are populated if not already recorded
         self.__version__
 
@@ -232,8 +233,8 @@ class Group(h5py.Group):
             new.attrs.update(self.attrs)
             new.natural_name = name
             # children
-            for k in self.keys():
-                self[k].copy(new)
+            for k, v in self.items():
+                super().copy(v, new, name=v.natural_name)
             new.flush()
             p = new.filepath
             new = wt_open(p)
@@ -245,6 +246,7 @@ class Group(h5py.Group):
                 parent.attrs['item_names'] = np.array(new, dtype='S')
             parent._update_natural_namespace()
             new = parent[name]
+            new._update_natural_namespace()
         # finish
         if verbose:
             print('{0} copied to {1}'.format(self.fullpath, new.fullpath))
@@ -290,8 +292,8 @@ class Group(h5py.Group):
         for k, v in self.attrs.items():
             new.attrs[k] = v
         # children
-        for k in self.keys():
-            self[k].copy(new, verbose=True)
+        for k, v in self.items():
+            super().copy(v, new, name=v.natural_name)
         # finish
         new.flush()
         del new

--- a/WrightTools/_open.py
+++ b/WrightTools/_open.py
@@ -3,6 +3,9 @@
 
 # --- import -------------------------------------------------------------------------------------
 
+
+import posixpath
+
 import h5py
 
 from . import collection as wt_collection
@@ -35,10 +38,11 @@ def open(filepath, edit_local=False):
         Root-level object in file.
     """
     f = h5py.File(filepath)
-    class_name = f['/'].attrs['class']
+    class_name = f[posixpath.sep].attrs['class']
+    name = f[posixpath.sep].attrs['name']
     if class_name == 'Data':
-        return wt_data.Data(filepath=filepath, edit_local=edit_local)
+        return wt_data.Data(filepath=filepath, name=name, edit_local=edit_local)
     elif class_name == 'Collection':
-        return wt_collection.Collection(filepath=filepath, edit_local=edit_local)
+        return wt_collection.Collection(filepath=filepath, name=name, edit_local=edit_local)
     else:
-        return wt_collection.Group(filepath=filepath, edit_local=edit_local)
+        return wt_collection.Group(filepath=filepath, name=name, edit_local=edit_local)

--- a/WrightTools/collection/_collection.py
+++ b/WrightTools/collection/_collection.py
@@ -58,13 +58,6 @@ class Collection(Group):
     def __setitem__(self, key, value):
         raise NotImplementedError
 
-    @property
-    def item_names(self):
-        """Item names."""
-        if 'item_names' not in self.attrs.keys():
-            self.attrs['item_names'] = np.array([], dtype='S')
-        return [s.decode() for s in self.attrs['item_names']]
-
     def create_collection(self, name='collection', position=None, **kwargs):
         """Create a new child colleciton.
 
@@ -137,29 +130,3 @@ class Collection(Group):
         for item in self._items:
             item.flush()
         self.file.flush()
-
-    def save(self, filepath=None, verbose=True):
-        """Save collection as root of a new file.
-
-        Parameters
-        ----------
-        filepath : string (optional)
-            Filepath to write. If None, file is created using natural_name.
-        verbose : boolean (optional)
-            Toggle talkback. Default is True
-
-        Returns
-        -------
-        str
-            Written filepath.
-        """
-        self.flush()  # ensure all changes are written to file
-        if filepath is None:
-            filepath = os.path.join(os.getcwd(), self.natural_name + '.wt5')
-        elif len(os.path.basename(filepath).split('.')) == 1:
-            filepath += '.wt5'
-        filepath = os.path.expanduser(filepath)
-        shutil.copyfile(src=self.filepath, dst=filepath)
-        if verbose:
-            print('file saved at', filepath)
-        return filepath

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -443,8 +443,6 @@ class Data(Group):
         else:
             shape = values.shape
             dtype = values.dtype
-            #if not shape == self.shape:
-            #    raise Exception  # TODO: better exception
         # create dataset
         dataset_id = self.require_dataset(name=name, data=values, shape=shape, dtype=dtype,
                                           chunks=True).id
@@ -481,8 +479,6 @@ class Data(Group):
         else:
             shape = values.shape
             dtype = values.dtype
-            #if not shape == self.shape:
-            #    raise Exception  # TODO: better exception
         # create dataset
         id = self.require_dataset(name=name, data=values, shape=shape, dtype=dtype).id
         variable = Variable(self, id, units=units, **kwargs)

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -46,8 +46,8 @@ class Data(Group):
         kwargs.pop('axis_names', None)
         kwargs.pop('channel_names', None)
         kwargs.pop('constant_names', None)
-        Group.__init__(self, *args, **kwargs)
         self.axes = []
+        Group.__init__(self, *args, **kwargs)
         for identifier in self.attrs.get('axes', []):
             identifier = identifier.decode()
             expression, units = identifier.split('{')
@@ -63,6 +63,8 @@ class Data(Group):
         self.kind
         self.source
         self.variable_names
+        # finish
+        self._update_natural_namespace()
 
     def __repr__(self):
         return '<WrightTools.Data \'{0}\' {1} at {2}>'.format(

--- a/tests/group/copy.py
+++ b/tests/group/copy.py
@@ -1,0 +1,24 @@
+"""Test group copy."""
+
+
+# --- import --------------------------------------------------------------------------------------
+
+
+import WrightTools as wt
+from WrightTools import datasets
+
+
+# --- test ----------------------------------------------------------------------------------------
+
+
+
+def test_simple():
+    original = wt.Collection(name='blaise')
+    new = c.copy()
+    assert original.fullpath != new.fullpath
+    for k, v in original.attrs.items():
+        assert new.attrs[k] == v
+    for k, v in original.items():
+        assert new[k] == v
+    original.close()
+    new.close()

--- a/tests/group/save.py
+++ b/tests/group/save.py
@@ -30,6 +30,24 @@ def assert_equal(a, b):
 # --- test ----------------------------------------------------------------------------------------
 
 
+def test_save_nested():
+    root = wt.Collection(name='root')
+    one = wt.Collection(name='one', parent=root)
+    wt.Collection(name='two', parent=one)
+    p = os.path.join(here, 'nested')
+    p = one.save(p)
+    assert os.path.isfile(p)
+    assert p.endswith('.wt5')
+    new = wt.open(p)
+    for k, v in one.attrs.items():
+        assert_equal(new.attrs[k], v)
+    for k, v in one.items():
+        assert_equal(new[k], v)
+    root.close()
+    new.close()
+    os.remove(p)
+
+
 def test_simple_copy():
     original = wt.Collection(name='blaise')
     new = original.copy()

--- a/tests/group/save.py
+++ b/tests/group/save.py
@@ -1,23 +1,58 @@
-"""Test group copy."""
+"""Test group copy and save."""
 
 
 # --- import --------------------------------------------------------------------------------------
 
 
+import os
+
 import WrightTools as wt
 from WrightTools import datasets
+
+
+# --- define --------------------------------------------------------------------------------------
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+# --- helpers -------------------------------------------------------------------------------------
+
+
+def assert_equal(a, b):
+    if hasattr(a, '__iter__'):
+        for ai, bi in zip(a, b):
+            assert ai == bi
+    else:
+        assert a == b
 
 
 # --- test ----------------------------------------------------------------------------------------
 
 
-def test_simple():
+def test_simple_copy():
     original = wt.Collection(name='blaise')
     new = original.copy()
     assert original.fullpath != new.fullpath
     for k, v in original.attrs.items():
-        assert new.attrs[k] == v
+        assert_equal(new.attrs[k], v)
     for k, v in original.items():
-        assert new[k] == v
+        assert_equal(new[k], v)
     original.close()
     new.close()
+
+
+def test_simple_save():
+    original = wt.Collection(name='blaise')
+    p = os.path.join(here, 'simple')
+    p = original.save(p)
+    assert os.path.isfile(p)
+    assert p.endswith('.wt5')
+    new = wt.open(p)
+    for k, v in original.attrs.items():
+        assert_equal(new.attrs[k], v)
+    for k, v in original.items():
+        assert_equal(new[k], v)
+    original.close()
+    new.close()
+    os.remove(p)

--- a/tests/group/save.py
+++ b/tests/group/save.py
@@ -11,10 +11,9 @@ from WrightTools import datasets
 # --- test ----------------------------------------------------------------------------------------
 
 
-
 def test_simple():
     original = wt.Collection(name='blaise')
-    new = c.copy()
+    new = original.copy()
     assert original.fullpath != new.fullpath
     for k, v in original.attrs.items():
         assert new.attrs[k] == v


### PR DESCRIPTION
  `_update` becomes `_update_natural_namespace`, to signfiy what it axtually does

all `copy` and `save` methods now inherited from `Group` parent class

`save` now allows for saving nested groups as root of new file---to do this, `save` calls `copy`

simplify `parent`

add try, except to `close` to "fix" bug that I do not understand