### PR TITLE
Move flush outside of loop

### DIFF
--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -313,8 +313,8 @@ class Data(Group):
             for c in self.channels:
                 data.create_channel(name=c.natural_name, values=c[idx], units=c.units)
             data.transform([a.expression for a in kept_axes if a.expression not in at.keys()])
-            out.flush()
             i += 1
+        out.flush()
         # return
         if verbose:
             es = [a.expression for a in kept_axes]

--- a/tests/data/chop.py
+++ b/tests/data/chop.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 """Test chop."""
 
 
@@ -78,3 +79,6 @@ def test_parent():
     parent = wt.Collection()
     chop = data.chop('wm', 'w2', parent=parent)
     assert chop.parent is parent
+
+if __name__ == "__main__":
+    test_3D_to_1D()

--- a/tests/data/chop.py
+++ b/tests/data/chop.py
@@ -80,5 +80,9 @@ def test_parent():
     chop = data.chop('wm', 'w2', parent=parent)
     assert chop.parent is parent
 
+
+# --- run -----------------------------------------------------------------------------------------
+
+
 if __name__ == "__main__":
     test_3D_to_1D()


### PR DESCRIPTION
Test still passed on my local machine, reduces overhead of chop operation by a factor of 2