### PR TITLE
Darien's little fixes. 

### DIFF
--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -611,6 +611,7 @@ class Data(Group):
 
 
         """
+        warnings.warn('heal', category=wt_exceptions.EntireDatasetInMemoryWarning)
         timer = wt_kit.Timer(verbose=False)
         with timer:
             # channel
@@ -1082,6 +1083,7 @@ class Data(Group):
         verbose : bool (optional)
             Toggle talkback. Default is True.
         """
+        warnings.warn('smooth', category=wt_exceptions.EntireDatasetInMemoryWarning)
         # get factors -----------------------------------------------------------------------------
 
         if isinstance(factors, list):

--- a/WrightTools/units.py
+++ b/WrightTools/units.py
@@ -45,7 +45,7 @@ od = {'mOD': ['1e3*x', 'x/1e3', r'mOD'],
 
 # position units (native: mm)
 position = {'nm_p': ['x/1e6', '1e6/x', r'nm'],
-            'um': ['x/1000.', '1000/x.', r'um'],
+            'um': ['x/1000.', '1000.*x', r'um'],
             'mm': ['x', 'x', r'mm'],
             'cm': ['10.*x', 'x/10.', r'cm'],
             'in': ['x*0.039370', '0.039370*x', r'in']}


### PR DESCRIPTION
Will note that memory warnings are untested because the [warning just passes](https://github.com/wright-group/WrightTools/blob/development/WrightTools/exceptions.py#L102).