### PR TITLE
Remove inverse

### DIFF
--- a/WrightTools/tuning/curve.py
+++ b/WrightTools/tuning/curve.py
@@ -81,7 +81,6 @@ class Linear:
         self.units = units
         self.motors = motors
         self.functions = [wt_kit.Spline(colors, motor.positions, k=1, s=0) for motor in motors]
-        self.i_functions = [wt_kit.Spline(motor.positions, colors, k=1, s=0) for motor in motors]
 
     def get_motor_positions(self, color):
         """Get motor positions.
@@ -162,8 +161,6 @@ class Spline:
         self.motors = motors
         self.functions = [scipy.interpolate.UnivariateSpline(
             colors, motor.positions, k=3, s=1000) for motor in motors]
-        self.i_functions = [scipy.interpolate.UnivariateSpline(
-            motor.positions, colors, k=3, s=1000) for motor in motors]
 
     def get_motor_positions(self, color):
         """Get motor positions.


### PR DESCRIPTION
The attempt to make splines for the inverse functions causes havoc when the input is not monotonic. The inverse functions are not actually used, anyway.

Fixes wright-group/PyCMDS#149