### PR TITLE
remove empty subscripts in labels

### DIFF
--- a/WrightTools/data/_axis.py
+++ b/WrightTools/data/_axis.py
@@ -90,7 +90,9 @@ class Axis(object):
         symbol = wt_units.get_symbol(self.units)
         label = r'$\mathsf{' + self.expression
         for v in self.variables:
-            label = label.replace(v.natural_name, '%s_{%s}' % (symbol, v.label))
+            vl = '%s_{%s}' % (symbol, v.label)
+            vl = vl.rstrip('_{}')  # label can be empty, should not propagate trailing underscore
+            label = label.replace(v.natural_name, vl)
         if self.units_kind:
             units_dictionary = getattr(wt_units, self.units_kind)
             label += r'\,'

--- a/WrightTools/data/_axis.py
+++ b/WrightTools/data/_axis.py
@@ -91,8 +91,9 @@ class Axis(object):
         label = r'$\mathsf{' + self.expression
         for v in self.variables:
             vl = '%s_{%s}' % (symbol, v.label)
-            vl = vl.rstrip('_{}')  # label can be empty, should not propagate trailing underscore
+            vl = vl.replace('_{}', '')  # label can be empty, no empty subscripts
             label = label.replace(v.natural_name, vl)
+        label += '}'
         if self.units_kind:
             units_dictionary = getattr(wt_units, self.units_kind)
             label += r'\,'


### PR DESCRIPTION
currently there is bad behavior in axis labels which cause the following 'clipping' when plotted using mathjax

![before 000](https://user-images.githubusercontent.com/8051086/37635344-0c7fac66-2bc9-11e8-9586-b8ee3b690c74.png)

I finally understand that this happens because of the empty subscript in the generated label string: `$\mathsf{\bar\nu_{}\,\left(cm^{-1}\right)}$`

note that if LaTeX is used to render the text (`wt.artists.apply_rcparams('publication')`) the clipping does not occur---so in some sense this might be considered a bug in mathjax or matplotlib's implementation thereof

regardless of fault, it's an easy problem to fix on our end

this simple commit ensures that empty subscripts are not propagated, such that the generated label string is `$\mathsf{\bar\nu\,\left(cm^{-1}\right)}$`

this results in the following, correctly formatted, figure

![after 000](https://user-images.githubusercontent.com/8051086/37635434-805f56f4-2bc9-11e8-82dd-94ef005274e3.png)