### PR TITLE
Make wright tools avoid opening multiple file objects which reference the same file

### DIFF
--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -145,7 +145,7 @@ class Group(h5py.Group, metaclass=MetaClass):
         elif edit_local and filepath:
             p = filepath
         for i in cls.instances.keys():
-            if i.startswith(os.path.abspath(filepath) + '::'):
+            if i.startswith(os.path.abspath(p) + '::'):
                 file = cls.instances[i].file
                 break
         if file is None:

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -168,9 +168,9 @@ class Group(h5py.Group, metaclass=MetaClass):
             instance = super(Group, cls).__new__(cls)
             cls.__init__(instance, **kwargs)
             cls.instances[fullpath] = instance
-        if tmpfile:
-            setattr(instance, '_tmpfile', tmpfile)
-            weakref.finalize(instance, instance.close)
+            if tmpfile:
+                setattr(instance, '_tmpfile', tmpfile)
+                weakref.finalize(instance, instance.close)
         return instance
 
     @property

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -239,6 +239,13 @@ class Group(h5py.Group, metaclass=MetaClass):
                 print("closing", repr(self))
                 self.file.flush()
                 self.file.close()
+                try:
+                    fd = self.fid.get_vfd_handle()
+                    os.close(fd)
+                except NotImplementedError:
+                    # only available with certain h5py drivers
+                    # not needed if not available
+                    pass
             except SystemError:
                 pass
             finally:

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -232,6 +232,7 @@ class Group(h5py.Group, metaclass=MetaClass):
         """
         from .collection import Collection
         from .data._data import Channel, Data, Variable
+        path = os.path.abspath(self.filepath) + '::'
         for kind in (Collection, Channel, Data, Variable, Group):
             rm = []
             for key in kind.instances.keys():
@@ -239,7 +240,7 @@ class Group(h5py.Group, metaclass=MetaClass):
                     rm.append(key)
             for key in rm:
                 kind.instances.pop(key, None)
-
+(
         if(self.fid.valid > 0):
             # for some reason, the following file operations sometimes fail
             # this stops execution of the method, meaning that the tempfile is never removed

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -242,7 +242,7 @@ class Group(h5py.Group, metaclass=MetaClass):
                 try:
                     fd = self.fid.get_vfd_handle()
                     os.close(fd)
-                except NotImplementedError:
+                except (NotImplementedError, ValueError):
                     # only available with certain h5py drivers
                     # not needed if not available
                     pass
@@ -342,6 +342,7 @@ class Group(h5py.Group, metaclass=MetaClass):
             super().copy(v, new, name=v.natural_name)
         # finish
         new.flush()
+        new.close()
         del new
         if verbose:
             print('file saved at', filepath)

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -238,13 +238,19 @@ class Group(h5py.Group, metaclass=MetaClass):
             try:
                 print("closing", repr(self))
                 self.file.flush()
-                self.file.close()
+                print('closed file', self.fid.id)
                 try:
                     fd = self.fid.get_vfd_handle()
-                    os.close(fd)
                 except (NotImplementedError, ValueError):
                     # only available with certain h5py drivers
                     # not needed if not available
+                    pass
+
+                self.file.close()
+                try:
+                    if fd:
+                        os.close(fd)
+                except OSError:
                     pass
             except SystemError:
                 pass

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -52,9 +52,7 @@ class Group(h5py.Group, metaclass=MetaClass):
             path = posixpath.sep
         else:
             path = posixpath.sep.join([parent, name])
-        # file
         self.filepath = file.filename
-        #file = h5py.File(self.filepath, 'a')
         file.require_group(parent)
         file.require_group(path)
         h5py.Group.__init__(self, bind=file[path].id)
@@ -171,7 +169,6 @@ class Group(h5py.Group, metaclass=MetaClass):
             cls.__init__(instance, **kwargs)
             cls.instances[fullpath] = instance
         if tmpfile:
-            print('setting weakref finalize for ', tmpfile)
             setattr(instance, '_tmpfile', tmpfile)
             weakref.finalize(instance, instance.close)
         return instance
@@ -236,10 +233,9 @@ class Group(h5py.Group, metaclass=MetaClass):
             # the following try case ensures that the tempfile code is always executed
             # ---Blaise 2018-01-08
             try:
-                print("closing", repr(self))
                 self.file.flush()
-                print('closed file', self.fid.id)
                 try:
+                    # Obtaining the file descriptor must be done prior to closing
                     fd = self.fid.get_vfd_handle()
                 except (NotImplementedError, ValueError):
                     # only available with certain h5py drivers
@@ -251,12 +247,12 @@ class Group(h5py.Group, metaclass=MetaClass):
                     if fd:
                         os.close(fd)
                 except OSError:
+                    # File already closed, e.g.
                     pass
             except SystemError:
                 pass
             finally:
                 if hasattr(self, '_tmpfile'):
-                    print("removing file", self._tmpfile)
                     os.close(self._tmpfile[0])
                     os.remove(self._tmpfile[1])
 

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -240,7 +240,7 @@ class Group(h5py.Group, metaclass=MetaClass):
                     rm.append(key)
             for key in rm:
                 kind.instances.pop(key, None)
-(
+
         if(self.fid.valid > 0):
             # for some reason, the following file operations sometimes fail
             # this stops execution of the method, meaning that the tempfile is never removed

--- a/tests/base.py
+++ b/tests/base.py
@@ -49,3 +49,11 @@ def test_tempfile_cleanup():
     assert os.path.isfile(path)
     c.close()
     assert not os.path.isfile(path)
+
+def test_nested():
+    c = wt.Collection()
+    cc = c.create_collection()
+    assert c.fid.id == cc.fid.id
+    c.file.close()
+    assert c.id.valid == 0
+    assert cc.id.valid == 0

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,6 +50,7 @@ def test_tempfile_cleanup():
     c.close()
     assert not os.path.isfile(path)
 
+
 def test_nested():
     c = wt.Collection()
     cc = c.create_collection()

--- a/tests/data/level.py
+++ b/tests/data/level.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 """Test level."""
 
 

--- a/tests/data/level.py
+++ b/tests/data/level.py
@@ -37,7 +37,7 @@ def test_3D():
     data.level('ai0', 1, 1)
     assert np.allclose(data.ai0[:, :1], [0.], atol=1e-3)
     data.close()
-    
+
 
 def test_channels():
     p = datasets.PyCMDS.wm_w2_w1_001

--- a/tests/group/save.py
+++ b/tests/group/save.py
@@ -5,7 +5,6 @@
 
 
 import os
-import time
 
 import numpy as np
 
@@ -92,7 +91,7 @@ def test_save_nested():
         assert_equal(new[k], v)
     root.close()
     new.close()
-    #os.remove(p)
+    os.remove(p)
 
 
 def test_simple_copy():
@@ -120,7 +119,6 @@ def test_simple_save():
         assert_equal(new[k], v)
     original.close()
     new.close()
-    time.sleep(1)
     os.remove(p)
 
 


### PR DESCRIPTION
Tests passed on my machine, running on the lab windows machine.

Resolves #570 

still want to add a particular test that was informative in fixing this problem
Also may be some clean up that should be done