### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     name='WrightTools',
     packages=find_packages(),
     package_data={'': extra_files},
+    python_requires='>=3.5',
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov',
                    'sphinx==1.6.5', 'sphinx-gallery==0.1.12', 'sphinx-rtd-theme'],


### PR DESCRIPTION
```
[kyle@argon WrightTools]$ pip2 install -e .
Obtaining file:///home/kyle/wright/wrighttools
WrightTools requires Python '>=3.5' but the running Python is 2.7.14
```

Actually communicate to pip that the package should not be installed on python 2