### PR TITLE
migrate requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-# from conda: conda create -n wrighttools --file requirements.txt
-# from pip: pip install -r requirements.txt
-h5py>=2.7.0
-imageio
-matplotlib>=2.0
-numexpr
-numpy
-python-dateutil
-pytz
-scipy
-tidy_headers
+.

--- a/setup.py
+++ b/setup.py
@@ -11,39 +11,61 @@ def read(fname):
     return open(os.path.join(here, fname)).read()
 
 
-extra_files = {'WrightTools': ['datasets', 'datasets/*', 'datasets/*/*', 'datasets/*/*/*',
-                               'datasets/*/*/*/*', 'VERSION', 'WT5_VERSION']}
+extra_files = {
+    "WrightTools": [
+        "datasets",
+        "datasets/*",
+        "datasets/*/*",
+        "datasets/*/*/*",
+        "datasets/*/*/*/*",
+        "VERSION",
+        "WT5_VERSION",
+    ]
+}
 
-with open(os.path.join(here, 'requirements.txt')) as f:
-    required = f.read().splitlines()
-
-with open(os.path.join(here, 'WrightTools', 'VERSION')) as version_file:
+with open(os.path.join(here, "WrightTools", "VERSION")) as version_file:
     version = version_file.read().strip()
 
 setup(
-    name='WrightTools',
-    packages=find_packages(exclude=('tests', 'tests.*')),
+    name="WrightTools",
+    packages=find_packages(exclude=("tests", "tests.*")),
     package_data=extra_files,
-    python_requires='>=3.5',
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov',
-                   'sphinx==1.6.5', 'sphinx-gallery==0.1.12', 'sphinx-rtd-theme'],
-    install_requires=required,
-    extras_require={'docs': ['sphinx-gallery==0.1.12']},
+    python_requires=">=3.5",
+    setup_requires=["pytest-runner"],
+    tests_require=[
+        "pytest",
+        "pytest-cov",
+        "sphinx==1.6.5",
+        "sphinx-gallery==0.1.12",
+        "sphinx-rtd-theme",
+    ],
+    install_requires=[
+        "h5py",
+        "imageio",
+        "matplotlib>=2.0",
+        "numexpr",
+        "numpy",
+        "python-dateutil",
+        "pytz",
+        "scipy",
+        "tidy_headers",
+    ],
+    extras_require={"docs": ["sphinx-gallery==0.1.12"]},
     version=version,
-    description='Tools for loading, processing, and plotting multidimensional spectroscopy data.',
-    long_description=read('README.rst'),
-    author='WrightTools Developers',
-    license='MIT',
-    url='http://wright.tools',
-    keywords='spectroscopy science multidimensional visualization',
-    classifiers=['Development Status :: 5 - Production/Stable',
-                 'Intended Audience :: Science/Research',
-                 'License :: OSI Approved :: MIT License',
-                 'Natural Language :: English',
-                 'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.5',
-                 'Programming Language :: Python :: 3.6',
-                 'Topic :: Scientific/Engineering',
-                 ]
+    description="Tools for loading, processing, and plotting multidimensional spectroscopy data.",
+    long_description=read("README.rst"),
+    author="WrightTools Developers",
+    license="MIT",
+    url="http://wright.tools",
+    keywords="spectroscopy science multidimensional visualization",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering",
+    ],
 )


### PR DESCRIPTION
from what I can see, we have been using `requirements.txt` wrong

[see this discussion on python.org](https://packaging.python.org/discussions/install-requires-vs-requirements/)

WrightTools' requirements should be in `setup.py` _first_, as this PR establishes

by having the stub requirements file, we still get the `pip install -r requirements.txt` behavior that we like

but distribution does not rely on requirements anymore
