### PR TITLE
allow mag as a kwarg to normalize

### DIFF
--- a/WrightTools/data/_channel.py
+++ b/WrightTools/data/_channel.py
@@ -107,7 +107,7 @@ class Channel(Dataset):
         """Channel magnitude (maximum deviation from null)."""
         return self.major_extent
 
-    def normalize(self):
+    def normalize(self, factor=1):
         """Normalize a Channel, set `null` to 0 and the mag to 1."""
 
         def f(dataset, s, null, mag):
@@ -115,9 +115,11 @@ class Channel(Dataset):
             dataset[s] /= mag
 
         if self.signed:
-            mag = self.mag()
+            mag = self.mag() / factor
         else:
-            mag = self.max()
+            mag = self.max() / factor
+
+        print(mag, "2@@@@@@@@@@@@@@@@@@@@@")
         self.chunkwise(f, null=self.null, mag=mag)
         self._null = 0
 

--- a/WrightTools/data/_channel.py
+++ b/WrightTools/data/_channel.py
@@ -107,19 +107,23 @@ class Channel(Dataset):
         """Channel magnitude (maximum deviation from null)."""
         return self.major_extent
 
-    def normalize(self, factor=1):
-        """Normalize a Channel, set `null` to 0 and the mag to 1."""
+    def normalize(self, mag=1.):
+        """Normalize a Channel, set `null` to 0 and the mag to given value.
+
+        Parameters
+        ----------
+        mag : float (optional)
+            New value of mag. Default is 1.
+        """
 
         def f(dataset, s, null, mag):
             dataset[s] -= null
             dataset[s] /= mag
 
         if self.signed:
-            mag = self.mag() / factor
+            mag = self.mag() / mag
         else:
-            mag = self.max() / factor
-
-        print(mag, "2@@@@@@@@@@@@@@@@@@@@@")
+            mag = self.max() / mag
         self.chunkwise(f, null=self.null, mag=mag)
         self._null = 0
 

--- a/tests/data/channel/normalize.py
+++ b/tests/data/channel/normalize.py
@@ -4,6 +4,8 @@
 # --- import --------------------------------------------------------------------------------------
 
 
+import random
+
 import WrightTools as wt
 from WrightTools import datasets
 
@@ -17,6 +19,17 @@ def test_LDS821():
     data.signal.normalize()
     assert data.signal.null == 0.
     assert data.signal.max() == 1.
+    data.close()
+
+
+def test_LDS821_mag_random():
+    p = datasets.BrunoldrRaman.LDS821_514nm_80mW
+    data = wt.data.from_BrunoldrRaman(p)
+    mag = random.random() + 0.5
+    data.signal.normalize(mag)
+    assert data.signal.null == 0.
+    assert data.signal.max() == mag
+    assert data.signal.mag() == mag
     data.close()
 
 
@@ -41,10 +54,24 @@ def test_negative_wigner():
     data.close()
 
 
+def test_negative_wigner_mag_1p1():
+    p = datasets.COLORS.v2p2_WL_wigner
+    data = wt.data.from_COLORS(p)
+    data.ai0 *= -1
+    data.ai0.signed = True
+    data.ai0.normalize(1.1)
+    assert data.ai0.null == 0.
+    assert data.ai0.min() == -1.1
+    assert data.ai0.mag() == 1.1
+    data.close()
+
+
 # --- run -----------------------------------------------------------------------------------------
 
 
 if __name__ == "__main__":
     test_LDS821()
+    test_LDS821_mag_random()
     test_wigner()
     test_negative_wigner()
+    test_negative_wigner_mag_1p1()

--- a/tests/data/channel/normalize.py
+++ b/tests/data/channel/normalize.py
@@ -4,7 +4,7 @@
 # --- import --------------------------------------------------------------------------------------
 
 
-import random
+import numpy as np
 
 import WrightTools as wt
 from WrightTools import datasets
@@ -22,14 +22,14 @@ def test_LDS821():
     data.close()
 
 
-def test_LDS821_mag_random():
+def test_LDS821_mag_0p5():
     p = datasets.BrunoldrRaman.LDS821_514nm_80mW
     data = wt.data.from_BrunoldrRaman(p)
-    mag = random.random() + 0.5
+    mag = 0.5
     data.signal.normalize(mag)
-    assert data.signal.null == 0.
-    assert data.signal.max() == mag
-    assert data.signal.mag() == mag
+    assert np.isclose(data.signal.null, 0.)
+    assert np.isclose(data.signal.max(), mag)
+    assert np.isclose(data.signal.mag(), mag)
     data.close()
 
 
@@ -37,8 +37,8 @@ def test_wigner():
     p = datasets.COLORS.v2p2_WL_wigner
     data = wt.data.from_COLORS(p)
     data.ai0.normalize()
-    assert data.ai0.null == 0.
-    assert data.ai0.max() == 1.
+    assert np.isclose(data.ai0.null, 0.)
+    assert np.isclose(data.ai0.max(), 1.)
     data.close()
 
 
@@ -48,9 +48,9 @@ def test_negative_wigner():
     data.ai0 *= -1
     data.ai0.signed = True
     data.ai0.normalize()
-    assert data.ai0.null == 0.
-    assert data.ai0.min() == -1.
-    assert data.ai0.mag() == 1.
+    assert np.isclose(data.ai0.null, 0.)
+    assert np.isclose(data.ai0.min(), -1.)
+    assert np.isclose(data.ai0.mag(), 1.)
     data.close()
 
 
@@ -60,9 +60,9 @@ def test_negative_wigner_mag_1p1():
     data.ai0 *= -1
     data.ai0.signed = True
     data.ai0.normalize(1.1)
-    assert data.ai0.null == 0.
-    assert data.ai0.min() == -1.1
-    assert data.ai0.mag() == 1.1
+    assert np.isclose(data.ai0.null, 0.)
+    assert np.isclose(data.ai0.min(), -1.1)
+    assert np.isclose(data.ai0.mag(), 1.1)
     data.close()
 
 
@@ -71,7 +71,7 @@ def test_negative_wigner_mag_1p1():
 
 if __name__ == "__main__":
     test_LDS821()
-    test_LDS821_mag_random()
+    test_LDS821_mag_0p5()
     test_wigner()
     test_negative_wigner()
     test_negative_wigner_mag_1p1()


### PR DESCRIPTION
by default, normalize scales a channel such that `null` goes to zero and `mag` goes to one

adding kwarg such that users may specify a specific target for `mag`

- [x] basic behavior
- [x] consistency in all places normalize is offered
- [x] tests