### PR TITLE
Set universal to 0

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -17,7 +17,7 @@ fi
 # build
 printf "\033[1;35mbuilding...\033[0m\n"
 $PYTHON setup.py sdist
-$PYTHON setup.py bdist_wheel --universal
+$PYTHON setup.py bdist_wheel
 # upload
 printf "\033[1;35muploading...\033[0m\n"
 while true; do

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [bdist_wheel]
-universal=1
+universal=0
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
Universial here means python2 and python3, not architecture/platform.
Since we are python3 only, it is confusing to have a wheel created with "py2.py3" in the file name