### PR TITLE
change index natural name

### DIFF
--- a/WrightTools/data/_solis.py
+++ b/WrightTools/data/_solis.py
@@ -91,16 +91,16 @@ def from_Solis(filepath, name=None, parent=None, verbose=True):
     arr = data.create_channel(name="signal", values=arr, signed=False, units="Hz")
     axis0 = np.array(axis0)
     if float(attrs["Grating Groove Density (l/mm)"]) == 0:
-        xname = "xpos"
+        xname = "xindex"
         xunits = None
     else:
         xname = "wm"
         xunits = "nm"
     data.create_variable(name=xname, values=axis0[:, None], units=xunits)
     data.create_variable(
-        name="ypos", values=np.arange(arr.shape[1])[None, :], units=None
+        name="yindex", values=np.arange(arr.shape[1])[None, :], units=None
     )
-    data.transform(data.variables[0].natural_name, "ypos")
+    data.transform(data.variables[0].natural_name, "yindex")
 
     for key, val in attrs.items():
         data.attrs[key] = val

--- a/tests/data/from_Solis.py
+++ b/tests/data/from_Solis.py
@@ -28,6 +28,7 @@ def test_xpos_ypos_fluorescence():
     assert data.units == (None, None)
     data.close()
 
+
 if __name__ == "__main__":
     test_wm_ypos_fluorescence_with_filter()
     test_xpos_ypos_fluorescence()

--- a/tests/data/from_Solis.py
+++ b/tests/data/from_Solis.py
@@ -15,7 +15,7 @@ def test_wm_ypos_fluorescence_with_filter():
     p = datasets.Solis.wm_ypos_fluorescence_with_filter
     data = wt.data.from_Solis(p)
     assert data.shape == (2560, 2160)
-    assert data.axis_expressions == ("wm", "ypos")
+    assert data.axis_expressions == ("wm", "yindex")
     assert data.units == ("nm", None)
     data.close()
 
@@ -24,7 +24,7 @@ def test_xpos_ypos_fluorescence():
     p = datasets.Solis.xpos_ypos_fluorescence
     data = wt.data.from_Solis(p)
     assert data.shape == (2560, 2160)
-    assert data.axis_expressions == ("xpos", "ypos")
+    assert data.axis_expressions == ("xindex", "yindex")
     assert data.units == (None, None)
     data.close()
 


### PR DESCRIPTION
Solis variables that track array coordinates now have names `xindex` and `yindex`, instead of `ypos`  and `xpos`.  New names are more concise and saves the namespace of position for variables with spatial units.