### PR TITLE
Update readthedocs.yml to python3.6

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,7 @@
 requirements_file: requirements.txt
 
 python:
+  version: 3.6
   pip_install: true
   extra_requirements: [docs]
   


### PR DESCRIPTION
There is an issue somewhere within pip/setuptools (external to WT) which seems to be preventing builds from proceeding currently.
Trying to update the build system to 3.6 as a mitigation strategy (also our most used version anyway)