### PR TITLE
Make instances a hidden attribute

### DIFF
--- a/WrightTools/_dataset.py
+++ b/WrightTools/_dataset.py
@@ -22,7 +22,7 @@ from . import units as wt_units
 class Dataset(h5py.Dataset):
     """Array-like data container."""
 
-    instances = {}
+    _instances = {}
     class_name = "Dataset"
 
     def __getitem__(self, index):
@@ -88,12 +88,12 @@ class Dataset(h5py.Dataset):
     def __new__(cls, parent, id, **kwargs):
         """New object formation handler."""
         fullpath = parent.fullpath + h5py.h5i.get_name(id).decode()
-        if fullpath in cls.instances.keys():
-            return cls.instances[fullpath]
+        if fullpath in cls._instances.keys():
+            return cls._instances[fullpath]
         else:
             instance = super(Dataset, cls).__new__(cls)
             cls.__init__(instance, parent, id, **kwargs)
-            cls.instances[fullpath] = instance
+            cls._instances[fullpath] = instance
             return instance
 
     def __repr__(self):

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -239,8 +239,9 @@ class Group(h5py.Group, metaclass=MetaClass):
     def close(self):
         """Close the file that contains the Group.
 
-        All groups which are in the file will be closed and removed from the _instances dictionaries.
-        Tempfiles, if they exist, will be removed.
+        All groups which are in the file will be closed and removed from the
+        _instances dictionaries.
+        Tempfiles, if they exist, will be removed
         """
         from .collection import Collection
         from .data._data import Channel, Data, Variable

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -40,7 +40,7 @@ class MetaClass(type(h5py.Group)):
 class Group(h5py.Group, metaclass=MetaClass):
     """Container of groups and datasets."""
 
-    instances = {}
+    _instances = {}
     class_name = "Group"
 
     def __init__(self, file=None, parent=None, name=None, **kwargs):
@@ -154,11 +154,11 @@ class Group(h5py.Group, metaclass=MetaClass):
         elif edit_local and filepath:
             p = filepath
         p = str(p)
-        for i in cls.instances.keys():
+        for i in cls._instances.keys():
             if i.startswith(os.path.abspath(p) + "::"):
-                file = cls.instances[i].file
-                if hasattr(cls.instances[i], "_tmpfile"):
-                    tmpfile = cls.instances[i]._tmpfile
+                file = cls._instances[i].file
+                if hasattr(cls._instances[i], "_tmpfile"):
+                    tmpfile = cls._instances[i]._tmpfile
                 break
         if file is None:
             file = h5py.File(p, "a")
@@ -171,14 +171,14 @@ class Group(h5py.Group, metaclass=MetaClass):
         fullpath = p + "::" + parent + name
         # create and/or return
         try:
-            instance = cls.instances[fullpath]
+            instance = cls._instances[fullpath]
         except KeyError:
             kwargs["file"] = file
             kwargs["parent"] = parent
             kwargs["name"] = natural_name
             instance = super(Group, cls).__new__(cls)
             cls.__init__(instance, **kwargs)
-            cls.instances[fullpath] = instance
+            cls._instances[fullpath] = instance
             if tmpfile:
                 setattr(instance, "_tmpfile", tmpfile)
                 weakref.finalize(instance, instance.close)
@@ -232,14 +232,14 @@ class Group(h5py.Group, metaclass=MetaClass):
             from .collection import Collection
 
             key = posixpath.dirname(self.fullpath) + posixpath.sep
-            self._parent = Collection.instances[key]
+            self._parent = Collection._instances[key]
         finally:
             return self._parent
 
     def close(self):
         """Close the file that contains the Group.
 
-        All groups which are in the file will be closed and removed from the instances dictionaries.
+        All groups which are in the file will be closed and removed from the _instances dictionaries.
         Tempfiles, if they exist, will be removed.
         """
         from .collection import Collection
@@ -248,11 +248,11 @@ class Group(h5py.Group, metaclass=MetaClass):
         path = os.path.abspath(self.filepath) + "::"
         for kind in (Collection, Channel, Data, Variable, Group):
             rm = []
-            for key in kind.instances.keys():
+            for key in kind._instances.keys():
                 if key.startswith(path):
                     rm.append(key)
             for key in rm:
-                kind.instances.pop(key, None)
+                kind._instances.pop(key, None)
 
         if self.fid.valid > 0:
             # for some reason, the following file operations sometimes fail

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1148,7 +1148,7 @@ class Data(Group):
             index = self.channel_names.index(k)
             # rename
             new[v] = obj, index
-            obj.instances.pop(obj.fullpath, None)
+            obj._instances.pop(obj.fullpath, None)
             obj.natural_name = str(v)
             # remove old references
             del self[k]
@@ -1199,7 +1199,7 @@ class Data(Group):
             index = self.variable_names.index(k)
             # rename
             new[v] = obj, index
-            obj.instances.pop(obj.fullpath, None)
+            obj._instances.pop(obj.fullpath, None)
             obj.natural_name = str(v)
             # remove old references
             del self[k]


### PR DESCRIPTION
This is not useful outside of the WT internals, and should not be something relied upon by anyone else.

In the most technical sense, this is a breaking API change, but I do not think this warrants 4.0, as it had no utility and should not have been part of the public API, that was simply an oversight.

Making this a private attribute has the added benefit of cleaning up the RTD pages.