### PR TITLE
Include tz import in dateutil

### DIFF
--- a/WrightTools/kit/_timestamp.py
+++ b/WrightTools/kit/_timestamp.py
@@ -8,6 +8,7 @@ import time
 
 import pytz
 import dateutil
+from dateutil import tz
 import datetime
 
 import numpy as np


### PR DESCRIPTION
Not imported by default, apparently

We are currently saved by it being imported somewhere within artists, but this is a small fix to ensure that updates in matplotlib or something else do not make timestamp error