### PR TITLE
MAINT: box-forced -> box for mpl

### DIFF
--- a/WrightTools/artists/_base.py
+++ b/WrightTools/artists/_base.py
@@ -190,7 +190,7 @@ class Axes(matplotlib.axes.Axes):
         elif along == "y":
             ax.set_xlim(ymin, ymax)
         ax.autoscale(enable=False)
-        ax.set_adjustable("box-forced")
+        ax.set_adjustable("box")
         ax.is_sideplot = True
         plt.setp(ax.get_xticklabels(), visible=False)
         plt.setp(ax.get_yticklabels(), visible=False)

--- a/WrightTools/artists/_helpers.py
+++ b/WrightTools/artists/_helpers.py
@@ -131,7 +131,7 @@ def add_sideplot(
     elif along == "y":
         axCorr = divider.append_axes("right", height, pad=pad, sharey=ax)
     axCorr.autoscale(False)
-    axCorr.set_adjustable("box-forced")
+    axCorr.set_adjustable("box")
     # bin
     if arrs_to_bin is not None:
         xi, yi, zi = arrs_to_bin


### PR DESCRIPTION
Closes #643 

The two are treated the same in mpl>=2.2, anyway, which we now require for interact2D
prevents a bunch of warnings from being raised