### PR TITLE
BUG: Parent attribute not present past items in root group

### DIFF
--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -231,7 +231,9 @@ class Group(h5py.Group, metaclass=MetaClass):
         except (AssertionError, AttributeError):
             from .collection import Collection
 
-            key = posixpath.dirname(self.fullpath) + posixpath.sep
+            key = posixpath.dirname(self.fullpath)
+            if key.endswith("::"):
+                key += posixpath.sep
             self._parent = Collection._instances[key]
         finally:
             return self._parent

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,7 +27,7 @@ def test_named_root_data():
 def test_parent_child():
     parent = wt.Collection(name="mother")
     child = wt.Collection(parent=parent, name="goose")
-    grandchild = wt.Collection(parent=parent, name="hen")
+    grandchild = wt.Collection(parent=child, name="hen")
     assert child.filepath == parent.filepath
     assert child.parent is parent
     assert grandchild.parent is child

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,8 +27,10 @@ def test_named_root_data():
 def test_parent_child():
     parent = wt.Collection(name="mother")
     child = wt.Collection(parent=parent, name="goose")
+    grandchild = wt.Collection(parent=parent, name="hen")
     assert child.filepath == parent.filepath
     assert child.parent is parent
+    assert grandchild.parent is child
 
 
 def test_single_instance_collection():


### PR DESCRIPTION
Tricky little subtle mistake that was not previously caught by tests or users, but was actually just plain wrong.

Our inheritance structure meant that `__getattribute__` was finding the correct method, but an error was raised (not an `AttributeError`, but rather a `KeyError`)

Unless python docs are incorrect, an `AttributeError` must have been raised by having the finally clause on this try/except on `_parent`, as the python docs indicate that `__getattr__` is _only_ called when `__getattribute__` raises `AttributeError`

This confusion led to obfuscation of where the problem occured.
I was able to track it down by explicitly calling `col.__getattribute__('parent')` rather than letting it go through it's normal course of method calls.