### PR TITLE
MAINT: No Longer except BaseException in leastsq

### DIFF
--- a/WrightTools/kit/_leastsq.py
+++ b/WrightTools/kit/_leastsq.py
@@ -71,7 +71,7 @@ def leastsqfitter(p0, datax, datay, function, verbose=False, cov_verbose=False):
         for i in range(len(pfit_leastsq)):
             try:
                 error.append(np.absolute(pcov[i][i]) ** 0.5)
-            except BaseException:
+            except IndexError:
                 error.append(0.00)
         perr_leastsq = np.array(error)
     # exit


### PR DESCRIPTION
From What I can tell, the only error that should be _able_ to be raised here is by indexing `pcov` after it has been set to infinity, which I think is rare to begin with.

Closes #681 