### PR TITLE
wisconsin–madison

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,36 +5,36 @@
     "creators": [
         {
             "orcid": "0000-0002-3845-824X", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Blaise J. Thompson"
         }, 
         {
             "orcid": "0000-0001-6167-8059", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Kyle F. Sunden"
         }, 
         {
             "orcid": "0000-0002-8922-8049", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Darien J. Morrow"
         }, 
         {
             "orcid": "0000-0003-4602-2961", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Daniel D. Kohler"
         }, 
         {
             "orcid": "0000-0002-9453-3590", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Nathan Andrew Neff-Mallon"
         }, 
         {
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Kyle J. Czech"
         }, 
         {
             "orcid": "0000-0001-6718-8341", 
-            "affiliation": "University of Wisconsin - Madison", 
+            "affiliation": "University of Wisconsin–Madison", 
             "name": "Emily M. Kaufman"
         }, 
         {


### PR DESCRIPTION
Never use spaces or hyphens when typing "University of Wisconsin–Madison"