### PR TITLE
ENH: Add temperature units, including from_Cary

### DIFF
--- a/WrightTools/collection/_cary.py
+++ b/WrightTools/collection/_cary.py
@@ -62,7 +62,7 @@ def from_Cary(filepath, name=None, parent=None, verbose=True):
         name = "cary"
     # import array
     lines = []
-    with open(filepath, "r") as f:
+    with open(filepath, "r", encoding="iso-8859-1") as f:
         header = f.readline()
         columns = f.readline()
         while True:
@@ -85,11 +85,13 @@ def from_Cary(filepath, name=None, parent=None, verbose=True):
     arr = np.array(lines).T
     # chew through all scans
     datas = Collection(name=name, parent=parent, edit_local=parent is not None)
+    units_dict = {"°c": "deg_C", "°f": "deg_F"}
     for i in range(0, len(header) - 1, 2):
         r = re.compile(r"[ \t\(\)]+")
         spl = r.split(columns[i])
         ax = spl[0].lower() if len(spl) > 0 else None
         units = spl[1].lower() if len(spl) > 1 else None
+        units = units_dict.get(units, units)
         dat = datas.create_data(header[i], kind="Cary", source=filepath)
         dat.create_variable(ax, arr[i][~np.isnan(arr[i])], units=units)
         dat.create_channel(

--- a/WrightTools/units.py
+++ b/WrightTools/units.py
@@ -163,6 +163,8 @@ def get_symbol(units) -> str:
         return r"\mathcal{F}"
     elif kind(units) == "pulse_width":
         return r"\sigma"
+    elif kind(units) == "temperature":
+        return r"Temp"
     else:
         return kind(units)
 

--- a/WrightTools/units.py
+++ b/WrightTools/units.py
@@ -57,6 +57,14 @@ position = {
 # pulse width units (native: FWHM)
 pulse_width = {"FWHM": ["x", "x", r"FWHM"]}
 
+# temperature units (native: K)
+temperature = {
+    "K": ["x", "x", r"K"],
+    "deg_C": ["x+273.15", "x-273.15", r"^\circ C"],
+    "deg_F": ["(x+459.67)*5/9", "x*9/5-456.67", r"^\circ F"],
+    "deg_R": ["x*5/9", "x*9/5", r"^\circ R"],
+}
+
 # time units (native: s)
 time = {
     "fs_t": ["x/1e15", "x*1e15", r"fs"],
@@ -79,6 +87,7 @@ dicts["position"] = position
 dicts["pulse_width"] = pulse_width
 dicts["fluence"] = fluence
 dicts["od"] = od
+dicts["temperature"] = temperature
 
 
 # --- functions -----------------------------------------------------------------------------------


### PR DESCRIPTION
This allows temperature units in WrightTools data objects, as well as the proper parsing of temperature dependent Cary csv files (tested on a data file which I have not sought permission to share as of yet).