### PR TITLE
ENH: Use natural name rather than full path, remove '/chop000/'

### DIFF
--- a/WrightTools/artists/_quick.py
+++ b/WrightTools/artists/_quick.py
@@ -119,7 +119,7 @@ def quick1D(
             plt.ylim(data_channel.min(), data_channel.max())
         # label axes
         ax.set_xlabel(axis.label, fontsize=18)
-        ax.set_ylabel(channel.name, fontsize=18)
+        ax.set_ylabel(channel.natural_name, fontsize=18)
         plt.xticks(rotation=45)
         plt.axvline(0, lw=2, c="k")
         plt.xlim(xi.min(), xi.max())


### PR DESCRIPTION
With constants being in the title now, this serves even less purpose than it used to, and is, if anything distracting from the purpose of quick1D, in my opinion.