### PR TITLE
Clean up _instances

### DIFF
--- a/WrightTools/_dataset.py
+++ b/WrightTools/_dataset.py
@@ -87,6 +87,8 @@ class Dataset(h5py.Dataset):
     def __new__(cls, parent, id, **kwargs):
         """New object formation handler."""
         fullpath = parent.fullpath + h5py.h5i.get_name(id).decode()
+        if fullpath.startswith("//"):
+            fullpath = fullpath[1:]
         if fullpath in cls._instances.keys():
             return cls._instances[fullpath]
         else:

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1342,7 +1342,7 @@ class Data(Group):
             index = self.channel_names.index(k)
             # rename
             new[v] = obj, index
-            obj._instances.pop(obj.fullpath, None)
+            Group._instances.pop(obj.fullpath, None)
             obj.natural_name = str(v)
             # remove old references
             del self[k]
@@ -1393,7 +1393,7 @@ class Data(Group):
             index = self.variable_names.index(k)
             # rename
             new[v] = obj, index
-            obj._instances.pop(obj.fullpath, None)
+            Group._instances.pop(obj.fullpath, None)
             obj.natural_name = str(v)
             # remove old references
             del self[k]

--- a/tests/base.py
+++ b/tests/base.py
@@ -31,6 +31,9 @@ def test_parent_child():
     assert child.filepath == parent.filepath
     assert child.parent is parent
     assert grandchild.parent is child
+    assert grandchild.fullpath in wt._group.Group._instances.keys()
+    assert child.fullpath in wt._group.Group._instances.keys()
+    assert parent.fullpath in wt._group.Group._instances.keys()
 
 
 def test_single_instance_collection():
@@ -60,3 +63,13 @@ def test_nested():
     c.file.close()
     assert c.id.valid == 0
     assert cc.id.valid == 0
+
+
+if __name__ == "__main__":
+    test_named_root_collection()
+    test_named_root_data()
+    test_parent_child()
+    test_single_instance_collection()
+    test_single_instance_data()
+    test_tempfile_cleanup()
+    test_nested()


### PR DESCRIPTION
There were some handling of instances that was simply wrong. This (hopefully) fixes those, and adds a test to ensure bad behavior does not return.

This also makes it clear in the code that there is only a single `_instances` dict for wt._group.Group, not separate ones for each subclass, as the code indicated previously (but in reality, they were all pointed to the same location)