### PR TITLE
MAINT: Remove deprecated rcparam: text.latex.unicode

### DIFF
--- a/WrightTools/artists/_base.py
+++ b/WrightTools/artists/_base.py
@@ -587,7 +587,6 @@ def apply_rcparams(kind="fast"):
         matplotlib.rcParams["contour.negative_linestyle"] = "solid"
     elif kind == "publication":
         matplotlib.rcParams["text.usetex"] = True
-        matplotlib.rcParams["text.latex.unicode"] = True
         preamble = "\\usepackage[cm]{sfmath}\\usepackage{amssymb}"
         matplotlib.rcParams["text.latex.preamble"] = preamble
         matplotlib.rcParams["mathtext.fontset"] = "cm"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "scikit-image",
         "h5py",
         "imageio",
-        "matplotlib>=2.2",
+        "matplotlib>=3.0",
         "numexpr",
         "numpy>=1.15.0",
         "python-dateutil",


### PR DESCRIPTION
Fixes deprecation warning:
```
>>> import WrightTools as wt
>>> wt.artists.apply_rcparams("publication")
/home/kyle/venvs/source/WrightTools/WrightTools/artists/_base.py:590: MatplotlibDeprecationWarning: 
The text.latex.unicode rcparam was deprecated in Matplotlib 2.2 and will be removed in 3.1.
  matplotlib.rcParams["text.latex.unicode"] = True
```

Interestingly, everything else I've seen, including release notes of API changes to matplotlib, indicate that this was a change in mpl 3.0, not mpl 2.2

Note: This PR also modifies minimum version of mpl dependency to ensure that desired unicode behavior is the default.