### PR TITLE
data.prune() does not work correctly when passing a bare string

### DIFF
--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1365,6 +1365,8 @@ class Data(Group):
                 self.remove_variable(v.natural_name, implied=False, verbose=verbose)
         if keep_channels is not True:
             try:
+                if isinstance(keep_channels, str):
+                    raise TypeError
                 indexes = tuple(keep_channels)
             except TypeError:
                 indexes = (keep_channels,)

--- a/tests/data/prune.py
+++ b/tests/data/prune.py
@@ -47,6 +47,18 @@ def test_prune_number():
     data.close()
 
 
+def test_prune_string():
+    p = datasets.PyCMDS.wm_w2_w1_000
+    data = wt.data.from_PyCMDS(p)
+    data.create_constant("d1")
+    data.prune("pyro1")
+    assert len(data.variables) == 4
+    assert set(data.variable_names) == {"wm", "w2", "w1", "d1"}
+    assert len(data.channels) == 1
+    assert data.channel_names[0] == "pyro1"
+    data.close()
+
+
 def test_prune_tuple():
     p = datasets.PyCMDS.wm_w2_w1_000
     data = wt.data.from_PyCMDS(p)
@@ -63,4 +75,5 @@ if __name__ == "__main__":
     test_prune_default()
     test_prune_false()
     test_prune_number()
+    test_prune_string()
     test_prune_tuple()


### PR DESCRIPTION
When I set the kwarg `keep_channels='mean'` the method does not have the desired result. But when I pass in `('mean')` the method has the desired result.