### PR TITLE
MAINT/TST: remove multiprocessing from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ addons:
 install:
   - pip install cython
   - pip install .
-  - pip install -U pytest pytest-mp "coverage<5"
+  - pip install -U pytest "coverage<5"
 before_script:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
-script: python setup.py test --addopts "--mp"
+script: python setup.py test


### PR DESCRIPTION
Causes pytest to fail with recent update