### PR TITLE
MAINT: Use scipy.signal instead of skimage for downscale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ install:
   - pip install cython
   - pip install .
   - pip install -U pytest "coverage<5"
-before_script:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3 # give xvfb some time to start
+services:
+  - xvfb
 script: python setup.py test

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -15,7 +15,7 @@ import h5py
 
 import scipy
 from scipy.interpolate import griddata, interp1d
-from skimage.transform import downscale_local_mean
+from scipy.signal import decimate
 
 from .._group import Group
 from .. import collection as wt_collection
@@ -897,10 +897,9 @@ class Data(Group):
     def downscale(self, tup, name=None, parent=None) -> "Data":
         """Down sample the data array using local averaging.
 
-        See `skimage.transform.downscale_local_mean`__ for more info.
+        See `scipy.signal.decimate`__ for more info.
 
-        __ http://scikit-image.org/docs/0.12.x/api/
-            skimage.transform.html#skimage.transform.downscale_local_mean
+        __ https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.decimate.html
 
         Parameters
         ----------
@@ -931,21 +930,26 @@ class Data(Group):
         else:
             parent.create_data(name=name)
 
+        def _nd_decimate(arr, factor):
+            if isinstance(factor, (int, type(None))):
+                factor = [factor] * arr.ndim
+            factor = [1 if f is None else f for f in factor]
+            for axis, f in enumerate(factor):
+                if arr.shape[axis] >= f:
+                    arr = decimate(arr, f, axis=axis)
+            return arr
+
         for channel in self.channels:
             name = channel.natural_name
             newdata.create_channel(
-                name=name, values=downscale_local_mean(channel[:], tup), units=channel.units
+                name=name, values=_nd_decimate(channel[:], tup), units=channel.units
             )
-        args = []
-        for i, axis in enumerate(self.axes):
-            if len(axis.variables) > 1:
-                raise NotImplementedError("downscale only works with simple axes currently")
-            variable = axis.variables[0]
+        for variable in self.variables:
             name = variable.natural_name
-            args.append(name)
-            slices = [slice(None, None, step) for step in tup]
-            newdata.create_variable(name=name, values=variable[slices], units=variable.units)
-        newdata.transform(*args)
+            newdata.create_variable(
+                name=name, values=_nd_decimate(variable[:], tup), units=variable.units
+            )
+        newdata.transform(*self.axis_names)
         return newdata
 
     def get_nadir(self, channel=0) -> tuple:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "pytest-cov", "sphinx", "sphinx-gallery==0.1.12", "sphinx-rtd-theme"],
     install_requires=[
-        "scikit-image",
         "h5py",
         "imageio",
         "matplotlib>=3.0",

--- a/tests/data/downscale.py
+++ b/tests/data/downscale.py
@@ -18,6 +18,11 @@ def test_downscale():
     b = a.downscale((3, 10))
     assert b.shape == (854, 216)
     assert b.axis_expressions == a.axis_expressions
+    # wt.artists.quick2D(a)
+    wt.artists.quick2D(b)
+    import matplotlib.pyplot as plt
+
+    plt.show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removes dependency scikit-image

Supercedes #860 (needed for testing on travis)