### PR TITLE
BUG: Make pcov a numpy scalar

### DIFF
--- a/WrightTools/kit/_leastsq.py
+++ b/WrightTools/kit/_leastsq.py
@@ -65,7 +65,7 @@ def leastsqfitter(p0, datax, datay, function, verbose=False, cov_verbose=False):
             if cov_verbose:
                 print(pcov)
         else:
-            pcov = np.inf
+            pcov = np.array(np.inf)
         # calculate and write errors
         error = []
         for i in range(len(pfit_leastsq)):

--- a/tests/kit/leastsqfitter.py
+++ b/tests/kit/leastsqfitter.py
@@ -1,0 +1,19 @@
+import numpy as np
+import WrightTools as wt
+
+
+def test_leastsq():
+    x = np.linspace(0, 10)
+    y = np.linspace(10, 0)
+    fit, cov = wt.kit.leastsqfitter([0, 0], x, y, lambda p, x: p[0] * x + p[1])
+    assert np.allclose(fit, [-1, 10])
+    assert np.allclose(cov, [0, 0])
+
+
+def test_leastsq_no_corr():
+    x = np.linspace(0, 10)
+    y = np.linspace(10, 0)
+    # The third parameter does not determine output, this caused an exception in wt <= 3.2.1
+    fit, cov = wt.kit.leastsqfitter([0, 0, 0], x, y, lambda p, x: p[0] * x + p[1])
+    assert np.allclose(fit, [-1, 10, 0])
+    assert np.allclose(cov, [0, 0, 0])


### PR DESCRIPTION
Fixes #868 

Should we add a test? if so, what can we do to reliably hit this condition?