### PR TITLE
Do not edit local when print tree

### DIFF
--- a/WrightTools/__main__.py
+++ b/WrightTools/__main__.py
@@ -19,7 +19,7 @@ def wt_tree():
     args = parser.parse_args()
 
     # Create the data/collection object
-    obj = wt.open(args.path, edit_local=True)[args.internal_path]
+    obj = wt.open(args.path)[args.internal_path]
 
     # Print the tree
     # If the object is a data object, it doesn't take depth as a parameter

--- a/tests/entry_points/wt_tree.py
+++ b/tests/entry_points/wt_tree.py
@@ -1,0 +1,19 @@
+import hashlib
+import WrightTools as wt
+import subprocess
+import os
+
+
+def test_no_change():
+    d = wt.Data()
+    d.save("test_no_change", overwrite=True)
+    d.close()
+    before = hashlib.sha1()
+    with open("test_no_change.wt5", "rb") as f:
+        before.update(f.read())
+    subprocess.call(["wt-tree", "test_no_change.wt5"])
+    after = hashlib.sha1()
+    with open("test_no_change.wt5", "rb") as f:
+        after.update(f.read())
+    os.remove("test_no_change.wt5")
+    assert before.digest() == after.digest()


### PR DESCRIPTION
I found that the `wt-tree` command was modifying the files themselves (not sure what was written, just that git told me they were different, and indeed the SHA sums were different)

Since tree _should_ be passive, this PR removes the `edit_local=True` kwarg such that it will create a copy rather than modify the original.

This impacts performance, as it has to do the copy operation, but means that it does not change the file itself, so that's a tradeoff I think we make.