### PR TITLE
print_tree with values for scalars

### DIFF
--- a/WrightTools/_dataset.py
+++ b/WrightTools/_dataset.py
@@ -117,9 +117,12 @@ class Dataset(h5py.Dataset):
     @property
     def _leaf(self):
         out = self.natural_name
+        if self.size == 1:
+            out += f" = {self.points}"
         if self.units is not None:
             out += " ({0})".format(self.units)
-        out += " {0}".format(self.shape)
+        if self.size != 1:
+            out += " {0}".format(self.shape)
         return out
 
     @property


### PR DESCRIPTION
example output: 

```
/ (perovskite_TA.wt5)
├── axes
│   ├── 0: w1=wm (eV) (1, 52, 1)
│   ├── 1: w2 (eV) (52, 1, 1)
│   └── 2: d2 (fs) (1, 1, 13)
├── constants
├── variables
│   ├── 0: labtime (52, 52, 13)
│   ├── 1: w1 (eV) (1, 52, 1)
│   ├── 2: w1_Crystal_1 (1, 52, 1)
│   ├── 3: w1_Delay_1 (1, 52, 1)
│   ├── 4: w1_Crystal_2 (1, 52, 1)
│   ├── 5: w1_Delay_2 (1, 52, 1)
│   ├── 6: w1_Mixer_1 (1, 52, 1)
│   ├── 7: w1_Mixer_2 (1, 52, 1)
│   ├── 8: w1_Mixer_3 (1, 52, 1)
│   ├── 9: w2 (eV) (52, 1, 1)
│   ├── 10: w2_Crystal_1 (52, 1, 1)
│   ├── 11: w2_Delay_1 (52, 1, 1)
│   ├── 12: w2_Crystal_2 (52, 1, 1)
│   ├── 13: w2_Delay_2 (52, 1, 1)
│   ├── 14: w2_Mixer_1 (52, 1, 1)
│   ├── 15: w2_Mixer_2 (52, 1, 1)
│   ├── 16: w2_Mixer_3 (52, 1, 1)
│   ├── 17: wm (eV) (1, 52, 1)
│   ├── 18: d0 = -0.00010199999999999989 (ps)
│   ├── 19: d0_position = 128.99998500000018 (mm)
│   ├── 20: d0_zero = 129.0 (mm)
│   ├── 21: d1 = -0.2993853461538461 (fs)
│   ├── 22: d1_position = 12.499644615384614 (mm)
│   ├── 23: d1_zero (mm) (52, 1, 1)
│   ├── 24: d2 (fs) (1, 1, 13)
│   ├── 25: d2_position = 4.985934429050979 (mm)
│   └── 26: d2_zero (mm) (52, 52, 1)
└── channels
    ├── 0: dOD (52, 52, 13)
    ├── 1: signal_mean (52, 52, 13)
    ├── 2: signal_std (52, 52, 13)
    ├── 3: signal_diff (52, 52, 13)
    ├── 4: pyro1_mean (52, 52, 13)
    ├── 5: pyro1_std (52, 52, 13)
    ├── 6: pyro1_diff (52, 52, 13)
    ├── 7: pyro2_mean (52, 52, 13)
    ├── 8: pyro2_std (52, 52, 13)
    └── 9: pyro2_diff (52, 52, 13)
```

Closes #894