### PR TITLE
Update link to black repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/python/black
     rev: stable
     hooks:
     - id: black

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Documentation at `wright.tools <http://wright.tools>`_.
    :target: http://wright.tools/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/ambv/black
+   :target: https://github.com/python/black
 
 .. image:: http://joss.theoj.org/papers/10.21105/joss.01141/status.svg
    :target: https://doi.org/10.21105/joss.01141


### PR DESCRIPTION
`black` has moved to be managed under the Python github org instead of Łukasz Langa's personal account.