### PR TITLE
Remove old conditions which are always True on supported python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: master
     hooks:
     - id: black
+      name: black
+      language: system
       args: [--line-length=99, --safe]
-      language_version: python3.6
+      entry: black

--- a/WrightTools/__init__.py
+++ b/WrightTools/__init__.py
@@ -5,8 +5,6 @@
 # --- import --------------------------------------------------------------------------------------
 
 
-import sys as _sys
-
 from .__citation__ import *
 from .__version__ import *
 from .__wt5_version__ import *
@@ -26,6 +24,4 @@ from .data._data import *
 
 # --- rcparams ------------------------------------------------------------------------------------
 
-
-if int(_sys.version.split(".")[0]) > 2:
-    artists.apply_rcparams("fast")
+artists.apply_rcparams("fast")

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -6,7 +6,6 @@
 
 import shutil
 import os
-import sys
 import pathlib
 import weakref
 import tempfile
@@ -82,7 +81,7 @@ class Group(h5py.Group, metaclass=MetaClass):
                     and isinstance(value[0], (str, os.PathLike))
                 ):
                     value = np.array(value, dtype="S")
-                elif sys.version_info > (3, 6):
+                else:
                     try:
                         value = os.fspath(value)
                     except TypeError:


### PR DESCRIPTION
Also updated precommit hook, because it was failing to initialize.

Note, that while we do still support 3.6, and the check was strictly
greater than, it should have been greater or equal, as `os.fspath`
was in fact introduced in 3.6.