### PR TITLE
MAINT: refactor savefig to accept mpl kwargs

### DIFF
--- a/WrightTools/artists/_helpers.py
+++ b/WrightTools/artists/_helpers.py
@@ -813,8 +813,11 @@ def plot_gridlines(ax=None, c="grey", lw=1, diagonal=False, zorder=2, makegrid=T
         ax.set_xlim(min_xi, max_xi)
 
 
-def savefig(path, fig=None, close=True, *, dpi=300):
+def savefig(path, fig=None, close=True, **kwargs):
     """Save a figure.
+
+    Note, that this method defaults to transparent background (``facecolor`` kwarg)
+    and to 300 dpi.
 
     Parameters
     ----------
@@ -825,22 +828,30 @@ def savefig(path, fig=None, close=True, *, dpi=300):
     close : bool (optional)
         Toggle closing of figure after saving. Default is True.
 
+    Keyword Parameters
+    ------------------
+    kwargs: any
+        All additional parameters are passed to the underlying matplotlib ``savefig`` call
+
     Returns
     -------
     str
         The full path where the figure was saved.
     """
-    # get fig
     if fig is None:
         fig = plt.gcf()
-    # get full path
+
     path = os.path.abspath(path)
-    # save
-    plt.savefig(path, dpi=dpi, transparent=False, pad_inches=1, facecolor="none")
-    # close
+
+    kwargs["dpi"] = kwargs.get("dpi", 300)
+    kwargs["transparent"] = kwargs.get("transparent", False)
+    kwargs["pad_inches"] = kwargs.get("pad_inches", 1)
+    kwargs["facecolor"] = kwargs.get("facecolor", "none")
+
+    fig.savefig(path, **kwargs)
+
     if close:
         plt.close(fig)
-    # finish
     return path
 
 

--- a/WrightTools/artists/_quick.py
+++ b/WrightTools/artists/_quick.py
@@ -151,7 +151,7 @@ def quick1D(
             else:
                 file_name = str(i).zfill(3)
             fpath = os.path.join(save_directory, file_name + ".png")
-            savefig(fpath, fig=fig)
+            savefig(fpath, fig=fig, facecolor="white")
             plt.close()
             if verbose:
                 print("image saved at", fpath)
@@ -233,8 +233,8 @@ def quick2D(
     else:
         cmap = "default"
     cmap = colormaps[cmap]
-    cmap.set_bad([0.75] * 3, 1.)
-    cmap.set_under([0.75] * 3, 1.)
+    cmap.set_bad([0.75] * 3, 1.0)
+    cmap.set_under([0.75] * 3, 1.0)
     # fname
     if fname is None:
         fname = data.natural_name
@@ -270,9 +270,9 @@ def quick2D(
             xr = xlim[1] - xlim[0]
             yr = ylim[1] - ylim[0]
             aspect = np.abs(yr / xr)
-            if 3 < aspect or aspect < 1 / 3.:
+            if 3 < aspect or aspect < 1 / 3.0:
                 # TODO: raise warning here
-                aspect = np.clip(aspect, 1 / 3., 3.)
+                aspect = np.clip(aspect, 1 / 3.0, 3.0)
         else:
             aspect = 1
         fig, gs = create_figure(
@@ -368,7 +368,7 @@ def quick2D(
             else:
                 file_name = str(i).zfill(3)
             fpath = os.path.join(save_directory, file_name + ".png")
-            savefig(fpath, fig=fig)
+            savefig(fpath, fig=fig, facecolor="white")
             plt.close()
             if verbose:
                 print("image saved at", fpath)


### PR DESCRIPTION
Maintains the same defaults, but allows user to override (and does not require adding kwargs manually)