### PR TITLE
MAINT/TST: Fix osf download link

### DIFF
--- a/tests/data/from_PyCMDS.py
+++ b/tests/data/from_PyCMDS.py
@@ -160,7 +160,7 @@ def test_centers_tolerance():
 
 
 def test_remote():
-    data = wt.data.from_PyCMDS("https://osf.io/download/rdn7v")
+    data = wt.data.from_PyCMDS("https://osf.io/rdn7v/download")
     assert data.shape == (21, 81)
     assert data.axis_expressions == ("wm", "w2=w1")
     data.close()


### PR DESCRIPTION
OSF used to accept either <key>/download or download/<key> in the url, that has changed