### PR TITLE
Fix inch conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - none-type units improperly handled by split through save/load
 - Copy colormaps to avoid editing default mpl colormaps
 - Correct units in output of split to be the same as input for axes
+- Conversion to/from inches was incorrect
 
 ## [3.2.7]
 

--- a/WrightTools/units.py
+++ b/WrightTools/units.py
@@ -52,7 +52,7 @@ position = {
     "um": ["x/1000.", "1000.*x", r"um"],
     "mm": ["x", "x", r"mm"],
     "cm": ["10.*x", "x/10.", r"cm"],
-    "in": ["x*0.039370", "0.039370*x", r"in"],
+    "in": ["x*25.4", "x/25.4", r"in"],
 }
 
 # pulse width units (native: FWHM)

--- a/tests/units.py
+++ b/tests/units.py
@@ -3,6 +3,7 @@
 
 # --- import -------------------------------------------------------------------------------------
 
+import numpy as np
 
 import WrightTools as wt
 from WrightTools import datasets
@@ -20,3 +21,8 @@ def test_axis_convert_exception():
         assert True
     else:
         assert False
+
+
+def test_in_mm_conversion():
+    assert np.isclose(wt.units.convert(25.4, "mm", "in"), 1.0)
+    assert np.isclose(wt.units.convert(1.0, "in", "mm"), 25.4)


### PR DESCRIPTION
## Changes

The inch conversion was wrong in one direction, and needlessly imprecise in the other, truncating 1/25.4, when using the exact factor is easy.

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable 
- [x] updated CHANGELOG.md
- [x] tests pass 
 
