### PR TITLE
Gaurd against trying to write readonly files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-
 ### Fixed
 - representation of units with micro prefix
+- Do not attempt to write attrs when file is read only
 
 ## [3.3.0]
 

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -66,9 +66,11 @@ class Group(h5py.Group, metaclass=MetaClass):
         h5py.Group.__init__(self, bind=file[str(path)].id)
         self.__n = 0
         self.fid = self.file.id
-        self.natural_name = name
+        if "name" not in self.attrs.keys():
+            self.natural_name = name
         # attrs
-        self.attrs["class"] = self.class_name
+        if "class" not in self.attrs.keys():
+            self.attrs["class"] = self.class_name
         if "created" not in self.attrs.keys():
             self.attrs["created"] = wt_kit.TimeStamp().RFC3339
         for key, value in kwargs.items():

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -66,8 +66,7 @@ class Group(h5py.Group, metaclass=MetaClass):
         h5py.Group.__init__(self, bind=file[str(path)].id)
         self.__n = 0
         self.fid = self.file.id
-        if "name" not in self.attrs.keys():
-            self.natural_name = name
+        self.natural_name = name
         # attrs
         if "class" not in self.attrs.keys():
             self.attrs["class"] = self.class_name
@@ -255,7 +254,9 @@ class Group(h5py.Group, metaclass=MetaClass):
             for k in dskeys:
                 obj = Dataset._instances.pop(k)
                 Dataset._instances[obj.fullpath] = obj
-        self._natural_name = self.attrs["name"] = value
+        self._natural_name = value
+        if self.file.mode is not None and self.file.mode != "r":
+            self.attrs["name"] = value
 
     @property
     def parent(self):

--- a/WrightTools/data/_channel.py
+++ b/WrightTools/data/_channel.py
@@ -66,13 +66,14 @@ class Channel(Dataset):
         self.units = units
         self.dimensionality = len(self.shape)
         # attrs
-        self.attrs.update(kwargs)
-        self.attrs["name"] = h5py.h5i.get_name(self.id).decode().split("/")[-1]
-        self.attrs["class"] = "Channel"
-        if signed is not None:
-            self.attrs["signed"] = signed
-        if null is not None:
-            self.attrs["null"] = null
+        if self._parent.file.mode is not None and self._parent.file.mode != "r":
+            self.attrs.update(kwargs)
+            self.attrs["name"] = h5py.h5i.get_name(self.id).decode().split("/")[-1]
+            self.attrs["class"] = "Channel"
+            if signed is not None:
+                self.attrs["signed"] = signed
+            if null is not None:
+                self.attrs["null"] = null
         for key, value in self.attrs.items():
             identifier = wt_kit.string2identifier(key)
             if not hasattr(self, identifier):
@@ -112,7 +113,7 @@ class Channel(Dataset):
         """Channel magnitude (maximum deviation from null)."""
         return self.major_extent
 
-    def normalize(self, mag=1.):
+    def normalize(self, mag=1.0):
         """Normalize a Channel, set `null` to 0 and the mag to given value.
 
         Parameters

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -70,12 +70,14 @@ class Data(Group):
             const = Constant(self, expression, units)
             self._constants.append(const)
         self._current_axis_identities_in_natural_namespace = []
-        self._on_constants_updated()
-        self._on_axes_updated()
-        # the following are populated if not already recorded
-        self.channel_names
-        self.source
-        self.variable_names
+        print(f"File mode: {self.file.mode}")
+        if self.file.mode is not None and self.file.mode != "r":
+            self._on_constants_updated()
+            self._on_axes_updated()
+            # the following are populated if not already recorded
+            self.channel_names
+            self.source
+            self.variable_names
 
     def __repr__(self) -> str:
         return "<WrightTools.Data '{0}' {1} at {2}>".format(

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -70,7 +70,6 @@ class Data(Group):
             const = Constant(self, expression, units)
             self._constants.append(const)
         self._current_axis_identities_in_natural_namespace = []
-        print(f"File mode: {self.file.mode}")
         if self.file.mode is not None and self.file.mode != "r":
             self._on_constants_updated()
             self._on_axes_updated()

--- a/WrightTools/data/_variable.py
+++ b/WrightTools/data/_variable.py
@@ -38,9 +38,10 @@ class Variable(Dataset):
         if units is not None:
             self.units = units
         # attrs
-        self.attrs.update(kwargs)
-        self.attrs["name"] = h5py.h5i.get_name(self.id).decode().split("/")[-1]
-        self.attrs["class"] = self.class_name
+        if self._parent.file.mode is not None and self._parent.file.mode != "r":
+            self.attrs.update(kwargs)
+            self.attrs["name"] = h5py.h5i.get_name(self.id).decode().split("/")[-1]
+            self.attrs["class"] = self.class_name
 
     @property
     def label(self) -> str:

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@
 
 import os
 import pytest
+import h5py
 
 import WrightTools as wt
 from WrightTools import datasets
@@ -87,6 +88,14 @@ def test_open_context():
         assert os.path.isfile(d.filepath)
     assert not os.path.isfile(d.filepath)
     assert d.id.valid == 0
+
+
+def test_open_readonly():
+    p = datasets.wt5.v1p0p1_MoS2_TrEE_movie
+    f = h5py.File(p, "r")
+    d = wt.Data(f)
+    assert d.file.mode == "r"
+    d.close()
 
 
 def test_close():


### PR DESCRIPTION
## Changes

Current behavior will _always_ try to write to attrs at init time, this PR prevents such writes where unecessary, allowing for read only files to  be opened.

What this does _not_ do: 
- provide an in house way of opening in read only mode (e.g. param/kwargs pass through to `wt.open`)
   - Only way to do it is by first opening the file in read only mode using h5py


## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable 
- [x] updated CHANGELOG.md
- [x] tests pass 
 
