### PR TITLE
Return min and max when file is read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Return min and max when file is read only
+
 ## [3.3.1]
 
 ### Added

--- a/WrightTools/_dataset.py
+++ b/WrightTools/_dataset.py
@@ -375,6 +375,13 @@ class Dataset(h5py.Dataset):
             def f(dataset, s):
                 return np.nanmax(dataset[s])
 
+            max_ = np.nanmax(list(self.chunkwise(f).values()))
+            try:
+                self.attrs["max"] = max_
+            except OSError:
+                # Cannot write file, just return, can't cache
+                return max_
+
             self.attrs["max"] = np.nanmax(list(self.chunkwise(f).values()))
         return self.attrs["max"]
 
@@ -385,7 +392,13 @@ class Dataset(h5py.Dataset):
             def f(dataset, s):
                 return np.nanmin(dataset[s])
 
-            self.attrs["min"] = np.nanmin(list(self.chunkwise(f).values()))
+            min_ = np.nanmin(list(self.chunkwise(f).values()))
+            try:
+                self.attrs["min"] = min_
+            except OSError:
+                # Cannot write file, just return, can't cache
+                return min_
+
         return self.attrs["min"]
 
     def slices(self):

--- a/tests/dataset/max.py
+++ b/tests/dataset/max.py
@@ -51,6 +51,7 @@ def test_read_only():
     assert "max" not in d.ai0.attrs
     assert np.isclose(d.ai0.max(), 0.2560301283785622)
     assert "max" not in d.ai0.attrs
+    d.close()
 
 
 # --- run -----------------------------------------------------------------------------------------

--- a/tests/dataset/max.py
+++ b/tests/dataset/max.py
@@ -4,6 +4,7 @@
 # --- import --------------------------------------------------------------------------------------
 
 
+import h5py
 import numpy as np
 
 import WrightTools as wt
@@ -42,6 +43,16 @@ def test_PyCMDS_wm_w2_w1_000():
     data.close()
 
 
+def test_read_only():
+    p = datasets.wt5.v1p0p1_MoS2_TrEE_movie
+    f = h5py.File(p, "r")
+    d = wt.Data(f)
+    assert np.isclose(d.w2.max(), 763.3587731728356)
+    assert "max" not in d.ai0.attrs
+    assert np.isclose(d.ai0.max(), 0.2560301283785622)
+    assert "max" not in d.ai0.attrs
+
+
 # --- run -----------------------------------------------------------------------------------------
 
 
@@ -49,3 +60,4 @@ if __name__ == "__main__":
     test_COLORS_v2p2_WL_wigner()
     test_JASCO_PbSe_batch_4_2012_02_21()
     test_PyCMDS_wm_w2_w1_000()
+    test_read_only()

--- a/tests/dataset/min.py
+++ b/tests/dataset/min.py
@@ -4,6 +4,7 @@
 # --- import --------------------------------------------------------------------------------------
 
 
+import h5py
 import numpy as np
 
 import WrightTools as wt
@@ -42,6 +43,16 @@ def test_PyCMDS_wm_w2_w1_000():
     data.close()
 
 
+def test_read_only():
+    p = datasets.wt5.v1p0p1_MoS2_TrEE_movie
+    f = h5py.File(p, "r")
+    d = wt.Data(f)
+    assert np.isclose(d.w2.min(), 584.7953254198521)
+    assert "min" not in d.ai0.attrs
+    assert np.isclose(d.ai0.min(), -0.008888)
+    assert "min" not in d.ai0.attrs
+
+
 # --- run -----------------------------------------------------------------------------------------
 
 
@@ -49,3 +60,4 @@ if __name__ == "__main__":
     test_COLORS_v2p2_WL_wigner()
     test_JASCO_PbSe_batch_4_2012_02_21()
     test_PyCMDS_wm_w2_w1_000()
+    test_read_only()

--- a/tests/dataset/min.py
+++ b/tests/dataset/min.py
@@ -51,6 +51,7 @@ def test_read_only():
     assert "min" not in d.ai0.attrs
     assert np.isclose(d.ai0.min(), -0.008888)
     assert "min" not in d.ai0.attrs
+    d.close()
 
 
 # --- run -----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

avoid caching min and max when it write is unavailable, still return

## Checklist

- [x] added tests, if applicable
- [NA] updated documentation, if applicable 
- [x] updated CHANGELOG.md
- [ ] tests pass 
 
