### PR TITLE
Try/except os.close for the tmpfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - Return min and max when file is read only
+- try/except the os.close call for tempfile (may already be gone in SWMR mode)
 
 ## [3.3.1]
 

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -309,8 +309,12 @@ class Group(h5py.Group, metaclass=MetaClass):
                 warnings.warn("SystemError: {0}".format(e))
             finally:
                 if hasattr(self, "_tmpfile"):
-                    os.close(self._tmpfile[0])
-                    os.remove(self._tmpfile[1])
+                    try:
+                        os.close(self._tmpfile[0])
+                        os.remove(self._tmpfile[1])
+                    except OSError:
+                        # File already closed, e.g.
+                        pass
 
     def copy(self, parent=None, name=None, verbose=True):
         """Create a copy under parent.


### PR DESCRIPTION
In SWMR mode, the tmpfile will be the same, and will be gone by subsequent close operations

Not adding a test because this is exceptionally unique circumstance that is hard to emulate in a single threaded test and it is only a try/except, so not really anything _to_ test well

## Checklist

- [NA] added tests, if applicable
- [NA] updated documentation, if applicable 
- [x] updated CHANGELOG.md
- [x] tests pass 
 
