### PR TITLE
Use datetime.isoformat to ensure timezone handling is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - Further handling for readonly files
 - Improved chopping with axes that span the kept axes removed
+- Timezone offset for `wt.kit.TimeStamp.RFC3339`
 
 ## [3.3.2]
 

--- a/WrightTools/kit/_timestamp.py
+++ b/WrightTools/kit/_timestamp.py
@@ -117,6 +117,9 @@ class TimeStamp:
     def __str__(self):
         """Readable representation."""
         return self.RFC3339
+    
+    def __eq__(self, other):
+        return self.datetime == other.datetime
 
     @property
     def date(self):
@@ -151,27 +154,7 @@ class TimeStamp:
 
         __ https://www.ietf.org/rfc/rfc3339.txt
         """
-        # get timezone offset
-        delta_sec = time.timezone
-        m, s = divmod(delta_sec, 60)
-        h, m = divmod(m, 60)
-        # timestamp
-        format_string = "%Y-%m-%dT%H:%M:%S.%f"
-        out = self.datetime.strftime(format_string)
-        # timezone
-        if delta_sec == 0.0:
-            out += "Z"
-        else:
-            if delta_sec > 0:
-                sign = "+"
-            elif delta_sec < 0:
-                sign = "-"
-
-            def as_string(num):
-                return str(np.abs(int(num))).zfill(2)
-
-            out += sign + as_string(h) + ":" + as_string(m)
-        return out
+        return self.datetime.isoformat()
 
     @property
     def RFC5322(self):

--- a/WrightTools/kit/_timestamp.py
+++ b/WrightTools/kit/_timestamp.py
@@ -117,7 +117,7 @@ class TimeStamp:
     def __str__(self):
         """Readable representation."""
         return self.RFC3339
-    
+
     def __eq__(self, other):
         return self.datetime == other.datetime
 

--- a/tests/kit/timestamp.py
+++ b/tests/kit/timestamp.py
@@ -36,6 +36,7 @@ def test_human():
 def test_RFC3339():
     ts = wt.kit.TimeStamp()
     assert ts.RFC3339
+    assert wt.kit.timestamp_from_RFC3339(ts.RFC3339) == ts
 
 
 def test_RFC5322():


### PR DESCRIPTION
## Changes

prior state cot the timezone wrong for RFC3339 on several accounts:

- always used local timezone provided by `time.timezone` rather than the datetime's timezone as set in the constructor
- `time.timezone` is defined as "seconds _west_ of UTC" which is opposite in sign to "normal" UTC offsets, so the resultant timezones had a sign flip. (e.g. here in Madison it is currently UTC-6 for CST, but the timestamp was printing as "+6:00" rather than "-6:00" for the RFC3339 representation (other representations either explicitly ignore tz offset or correctly converted to UTC before returning, so RFC3339 was the only affected)
- Overcomplicated way of doing what a provided method does, RFC3339 and ISO8601 are compatible standards, and we used the same exact format (only difference in output being the corrected sign)

## Checklist-
- [x] added tests, if applicable
- [ ] ~~updated documentation, if applicable~~
- [x] updated CHANGELOG.md
- [x] tests pass

