### PR TITLE
Avoid passing both vmin/vmax and norm kwargs to pcolor- methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Avoid passing both `vmin/vmax` and `norm` to `pcolor*` methods
+
 ## [3.3.3]
 
 ### Fixed

--- a/WrightTools/artists/_base.py
+++ b/WrightTools/artists/_base.py
@@ -82,6 +82,8 @@ class Axes(matplotlib.axes.Axes):
             self.set_ylabel(ylabel, fontsize=18)
 
     def _parse_limits(self, zi=None, data=None, channel_index=None, dynamic_range=False, **kwargs):
+        if "norm" in kwargs:
+            return kwargs
         if zi is not None:
             if "levels" in kwargs.keys():
                 levels = kwargs["levels"]


### PR DESCRIPTION
closes #971

## Changes

Avoid Deprecation warning in mpl

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

