### PR TITLE
Explicitly store axes as fixed width numpy strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - complete units overhaul, now using pint library
+- explicitly store axes as fixed string dtype
 
 ### Fixed
 - Avoid passing both `vmin/vmax` and `norm` to `pcolor*` methods

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -221,7 +221,7 @@ class Data(Group):
         Propagates updated axes properly.
         """
         # update attrs
-        self.attrs["axes"] = [a.identity.encode() for a in self._axes]
+        self.attrs["axes"] = np.array([a.identity.encode() for a in self._axes], dtype="S")
         # remove old attributes
         while len(self._current_axis_identities_in_natural_namespace) > 0:
             key = self._current_axis_identities_in_natural_namespace.pop(0)

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -241,7 +241,9 @@ class Data(Group):
         Propagates updated constants properly.
         """
         # update attrs
-        self.attrs["constants"] = np.array([a.identity.encode() for a in self._constants], dtype="S")
+        self.attrs["constants"] = np.array(
+            [a.identity.encode() for a in self._constants], dtype="S"
+        )
 
     def _print_branch(self, prefix, depth, verbose):
         def print_leaves(prefix, lis, vline=True):

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -241,7 +241,7 @@ class Data(Group):
         Propagates updated constants properly.
         """
         # update attrs
-        self.attrs["constants"] = [a.identity.encode() for a in self._constants]
+        self.attrs["constants"] = np.array([a.identity.encode() for a in self._constants], dtype="S")
 
     def _print_branch(self, prefix, depth, verbose):
         def print_leaves(prefix, lis, vline=True):


### PR DESCRIPTION
Needed for compatibility with bluesky/tiled (via msgpack_numpy)

## Changes

please describe your changes here :smiley:

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

