### PR TITLE
Validate units are in the unit registry on set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 - complete units overhaul, now using pint library
 - explicitly store axes as fixed string dtype
+- validate units are in the unit registry on set
 
 ### Fixed
 - Fixed bug in `from_COLORS` that misordered the relationship between variables and channels for 1D datasets.

--- a/WrightTools/_dataset.py
+++ b/WrightTools/_dataset.py
@@ -185,6 +185,8 @@ class Dataset(h5py.Dataset):
         if value is None:
             if "units" in self.attrs.keys():
                 self.attrs.pop("units")
+        elif value not in wt_units.ureg:
+            raise ValueError(f"'{value}' is not in the unit registry")
         else:
             try:
                 self.attrs["units"] = value

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -19,6 +19,7 @@ import h5py
 from ._dataset import Dataset
 from . import kit as wt_kit
 from . import exceptions as wt_exceptions
+from . import units as wt_units
 from . import __wt5_version__
 
 
@@ -270,6 +271,18 @@ class Group(h5py.Group, metaclass=MetaClass):
             self._parent = Group._instances[key]
         finally:
             return self._parent
+
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        if value == "None":
+            value = None
+        if value is not None and value not in wt_units.ureg:
+            raise ValueError(f"'{value}' is not in the unit registry")
+        self._units = value
 
     def close(self):
         """Close the file that contains the Group.

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -19,7 +19,6 @@ import h5py
 from ._dataset import Dataset
 from . import kit as wt_kit
 from . import exceptions as wt_exceptions
-from . import units as wt_units
 from . import __wt5_version__
 
 
@@ -271,18 +270,6 @@ class Group(h5py.Group, metaclass=MetaClass):
             self._parent = Group._instances[key]
         finally:
             return self._parent
-
-    @property
-    def units(self):
-        return self._units
-
-    @units.setter
-    def units(self, value):
-        if value == "None":
-            value = None
-        if value is not None and value not in wt_units.ureg:
-            raise ValueError(f"'{value}' is not in the unit registry")
-        self._units = value
 
     def close(self):
         """Close the file that contains the Group.

--- a/WrightTools/data/_axis.py
+++ b/WrightTools/data/_axis.py
@@ -142,6 +142,18 @@ class Axis(object):
         return functools.reduce(operator.mul, self.shape)
 
     @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        if value == "None":
+            value = None
+        if value is not None and value not in wt_units.ureg:
+            raise ValueError(f"'{value}' is not in the unit registry")
+        self._units = value
+
+    @property
     def units_kind(self) -> str:
         """Units kind."""
         return wt_units.kind(self.units)

--- a/tests/data/from_Aramis.py
+++ b/tests/data/from_Aramis.py
@@ -11,6 +11,8 @@ import pathlib
 
 here = pathlib.Path(__file__).parent
 
+wt.units.ureg.define("@alias count = Cnt")
+
 # --- test ----------------------------------------------------------------------------------------
 
 

--- a/tests/data/from_PyCMDS.py
+++ b/tests/data/from_PyCMDS.py
@@ -13,6 +13,7 @@ from WrightTools import datasets
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+wt.units.ureg.define("steps = []")
 
 # --- test ----------------------------------------------------------------------------------------
 

--- a/tests/units.py
+++ b/tests/units.py
@@ -29,26 +29,26 @@ def test_in_mm_conversion():
 
 
 def unit_registry_test1():
-    values = np.linspace(-1,1,51)
-    arr = np.linspace(0,1,51)
-    d = wt.Data(name='test')
+    values = np.linspace(-1, 1, 51)
+    arr = np.linspace(0, 1, 51)
+    d = wt.Data(name="test")
     try:
-        d.create_variable('Bgood', values=values, units='tesla')
-        d.transform('Bgood')
-    except ValueError :
+        d.create_variable("Bgood", values=values, units="tesla")
+        d.transform("Bgood")
+    except ValueError:
         assert False
     else:
         assert True
 
 
 def unit_registry_test2():
-    values = np.linspace(-1,1,51)
-    arr = np.linspace(0,1,51)
-    d = wt.Data(name='test')
+    values = np.linspace(-1, 1, 51)
+    arr = np.linspace(0, 1, 51)
+    d = wt.Data(name="test")
     try:
-        d.create_variable('Bbad', values=values, units='Tesla')
-        d.transform('Bbad')
-    except ValueError :
+        d.create_variable("Bbad", values=values, units="Tesla")
+        d.transform("Bbad")
+    except ValueError:
         assert True
     else:
         assert False

--- a/tests/units.py
+++ b/tests/units.py
@@ -26,3 +26,29 @@ def test_axis_convert_exception():
 def test_in_mm_conversion():
     assert np.isclose(wt.units.convert(25.4, "mm", "in"), 1.0)
     assert np.isclose(wt.units.convert(1.0, "in", "mm"), 25.4)
+
+
+def unit_registry_test1():
+    values = np.linspace(-1,1,51)
+    arr = np.linspace(0,1,51)
+    d = wt.Data(name='test')
+    try:
+        d.create_variable('Bgood', values=values, units='tesla')
+        d.transform('Bgood')
+    except ValueError :
+        assert False
+    else:
+        assert True
+
+
+def unit_registry_test2():
+    values = np.linspace(-1,1,51)
+    arr = np.linspace(0,1,51)
+    d = wt.Data(name='test')
+    try:
+        d.create_variable('Bbad', values=values, units='Tesla')
+        d.transform('Bbad')
+    except ValueError :
+        assert True
+    else:
+        assert False

--- a/tests/units.py
+++ b/tests/units.py
@@ -30,7 +30,6 @@ def test_in_mm_conversion():
 
 def unit_registry_test1():
     values = np.linspace(-1, 1, 51)
-    arr = np.linspace(0, 1, 51)
     d = wt.Data(name="test")
     try:
         d.create_variable("Bgood", values=values, units="tesla")
@@ -43,7 +42,6 @@ def unit_registry_test1():
 
 def unit_registry_test2():
     values = np.linspace(-1, 1, 51)
-    arr = np.linspace(0, 1, 51)
     d = wt.Data(name="test")
     try:
         d.create_variable("Bbad", values=values, units="Tesla")


### PR DESCRIPTION
Closes #1010

## Changes

Add `@property` for units to validate that they are in the registry for setting the units on axis, channel, and variable (the latter two handled by the common parent, Group)

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

