### PR TITLE
map_variable:  ignore filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - `artists._parse_limits` now recognizes channel `null` for signed data limits.
+- fixed bug where `Data.map_variable` did not interpolate on `yaqc-cmds` type Data
 
 ## [3.4.2]
 

--- a/WrightTools/_group.py
+++ b/WrightTools/_group.py
@@ -148,7 +148,7 @@ class Group(h5py.Group, metaclass=MetaClass):
     def __new__(cls, *args, **kwargs):
         """New object formation handler."""
         # extract
-        filepath = args[0] if len(args) > 0 else kwargs.get("filepath", None)
+        filepath = args[0] if len(args) > 0 else kwargs.pop("filepath", None)
         parent = args[1] if len(args) > 1 else kwargs.get("parent", None)
         natural_name = args[2] if len(args) > 2 else kwargs.get("name", cls.class_name.lower())
         edit_local = args[3] if len(args) > 3 else kwargs.pop("edit_local", False)

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1136,7 +1136,13 @@ class Data(Group):
             points = wt_units.converter(points, input_units, variable.units)
         # construct new data object
         special = [
-            "name", "axes", "constants", "channel_names", "variable_names", "filepath", "edit_local" 
+            "name",
+            "axes",
+            "constants",
+            "channel_names",
+            "variable_names",
+            "filepath",
+            "edit_local",
         ]
         kwargs = {k: v for k, v in self.attrs.items() if k not in special}
         if name is None:

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1135,7 +1135,9 @@ class Data(Group):
         else:
             points = wt_units.converter(points, input_units, variable.units)
         # construct new data object
-        special = ["name", "axes", "constants", "channel_names", "variable_names", "filepath"]
+        special = [
+            "name", "axes", "constants", "channel_names", "variable_names", "filepath", "edit_local" 
+        ]
         kwargs = {k: v for k, v in self.attrs.items() if k not in special}
         if name is None:
             name = "{0}_{1}_mapped".format(self.natural_name, variable.natural_name)

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -1135,7 +1135,7 @@ class Data(Group):
         else:
             points = wt_units.converter(points, input_units, variable.units)
         # construct new data object
-        special = ["name", "axes", "constants", "channel_names", "variable_names"]
+        special = ["name", "axes", "constants", "channel_names", "variable_names", "filepath"]
         kwargs = {k: v for k, v in self.attrs.items() if k not in special}
         if name is None:
             name = "{0}_{1}_mapped".format(self.natural_name, variable.natural_name)

--- a/tests/data/map_variable.py
+++ b/tests/data/map_variable.py
@@ -5,6 +5,7 @@
 
 
 import numpy as np
+import pytest
 
 import WrightTools as wt
 from WrightTools import datasets
@@ -42,11 +43,12 @@ def test_excess_data_kwarg_1D():
     data.close()
 
 
-def test_excess_data_kwarg_3D():
+@pytest.mark.skip("It's a long test")
+def test_v1p0p0():
     p = datasets.wt5.v1p0p0_perovskite_TA
     data = wt.open(p)
-    mapped = data.map_variable("w2", 11)
-    assert mapped.w2.size == 11
+    mapped = data.map_variable("w2", 2)
+    assert mapped.w2.size == 2
     data.close()
 
 
@@ -57,4 +59,4 @@ if __name__ == "__main__":
     test_array()
     test_int()
     test_excess_data_kwarg_1D()
-    test_excess_data_kwarg_3D()
+    test_v1p0p0()

--- a/tests/data/map_variable.py
+++ b/tests/data/map_variable.py
@@ -34,9 +34,27 @@ def test_int():
     data.close()
 
 
+def test_excess_data_kwarg_1D():
+    p = datasets.wt5.v1p0p0_perovskite_TA
+    data = wt.open(p).chop("w2", at={"w1=wm": [1.6, "eV"], "d2":[0, "fs"]})[0]
+    mapped = data.map_variable("w2", 11)
+    assert mapped.w2.size == 11
+    data.close()
+
+
+def test_excess_data_kwarg_3D():
+    p = datasets.wt5.v1p0p0_perovskite_TA
+    data = wt.open(p)
+    mapped = data.map_variable("w2", 11)
+    assert mapped.w2.size == 11
+    data.close()
+
+
 # --- run -----------------------------------------------------------------------------------------
 
 
 if __name__ == "__main__":
     test_array()
     test_int()
+    test_excess_data_kwarg_1D()
+    test_excess_data_kwarg_3D()


### PR DESCRIPTION
## Changes

map_variable ignores its filepath kwarg when creating new data, which improperly initialized variables and channels to prevent interpolation.  

Fixes issue #1039 

## Checklist

- [x] added tests, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

