### PR TITLE
Quick2d cmaps, and rotations of LinearSegmentColormaps via rotate_colormap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - `artists.interact2D` supports `cmap` kwarg.
 - iPython integration: autocomplete includes axis, variable, and channel names
+- `artists.quick2D` supports `cmap` kwarg.
+- `artists.rotate_colormap` allows multiple rotations of color cycles
 
 ### Changed
 - `artists.interact2D` uses matplotlib norm objects to control colormap scaling

--- a/WrightTools/artists/_colors.py
+++ b/WrightTools/artists/_colors.py
@@ -25,6 +25,7 @@ __all__ = [
     "grayify_cmap",
     "overline_colors",
     "plot_colormap_components",
+    "rotate_colormap",
 ]
 
 
@@ -139,7 +140,7 @@ def rotate_colormap(cmap, rotations, eps=0.0001):
     a new colormap.   Note:  these rotations are limited by the use of epsilon
     and may cause errors if the number of rotations is very large.  The last index value
     will be off by eps x rotations.   The method only works on tuples and arrays for segmentdata;
-    use the r parameter instead for make_cubehelix.
+    use the r parameter instead for make_cubehelix.   Not used for ListedColormaps.
 
     Parameters
     ----------
@@ -195,13 +196,13 @@ def rotate_colormap(cmap, rotations, eps=0.0001):
             for i in range(lnal):
                 arr = list(alphas[i])
                 arral.append(arr)
-            alphas = np.array(arral, dtpye=float)
+            alphas = np.array(arral, dtype=float)
     else:
-        reds = colors["red"]
-        greens = colors["green"]
-        blues = colors["blue"]
+        reds = np.array(colors["red"], dtype=float)
+        greens = np.array(colors["green"], dtype=float)
+        blues = np.array(colors["blue"], dtype=float)
         try:
-            alphas = colors["alpha"]
+            alphas = np.array(colors["alpha"], dtype=float)
             lnal = 1
         except:
             alphas = None

--- a/WrightTools/artists/_quick.py
+++ b/WrightTools/artists/_quick.py
@@ -168,6 +168,7 @@ def quick2D(
     channel=0,
     *,
     contours=0,
+    cmap=None,
     pixelated=True,
     dynamic_range=False,
     local=False,
@@ -228,13 +229,17 @@ def quick2D(
     chopped = data.chop(xaxis, yaxis, at=at, verbose=False)
     # colormap
     # get colormap
-    if data.channels[channel_index].signed:
-        cmap = "signed"
-    else:
-        cmap = "default"
-    cmap = colormaps[cmap]
-    cmap.set_bad([0.75] * 3, 1.0)
-    cmap.set_under([0.75] * 3, 1.0)
+    if isinstance(cmap, type(None)):
+        if data.channels[channel_index].signed:
+            cmap = "signed"
+            cmap = colormaps[cmap]
+            cmap.set_bad([0.75] * 3, 1.0)
+            cmap.set_under([0.75] * 3, 1.0)
+        else:
+            cmap = "default"
+            cmap = colormaps[cmap]
+            cmap.set_bad([0.75] * 3, 1.0)
+            cmap.set_under([0.75] * 3, 1.0)
     # fname
     if fname is None:
         fname = data.natural_name


### PR DESCRIPTION
## Changes

A method `rotate_colormap` was added to `wt.artists._colors`.   It takes a LinearSegmentedColormap and rotates it an integer number of times, returning a new LinearSegmentColormap.     It is not used for ListedColormaps.  Give it a try!

I allowed quick2D to use the `cmap` kwarg as it seems to work.

## Checklist

- [ ] added tests, if applicable  N/A
- [ ] updated documentation, if applicable N/A
- [X] updated CHANGELOG.md
- [ ] tests pass

