### PR TITLE
Update _join.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ## Changed
+- data.join now has MultidimensionalAxisError exception message
 - `Axis`: space character ("\s") in expressions are culled.
 - fixed `interact2D` bug: channel/axes can now be specified with non-zero index arguments
 

--- a/WrightTools/data/_join.py
+++ b/WrightTools/data/_join.py
@@ -89,13 +89,9 @@ def join(
         if d.axis_expressions != axis_expressions:
             raise wt_exceptions.ValueError("Joined data must have same axis_expressions")
         for a in d.axes:
-            if len(np.squeeze(a.variables[0][:]).shape) > 1:
-                raise wt_exceptions.ValueError("Axis '" + a.natural_name + "' of datas[" + 
-                                                str(datas.index(d)) +"] ('" + d.natural_name+
-                                                "') must be 1D, but currently has " + 
-                                                str(len(np.squeeze(a.variables[0][:]).shape)) +
-                                                ' nontrivial axes'
-                                                )  
+            if a.variables[0][:].squeeze().ndim > 1:
+                raise wt_exceptions.MultidimensionalAxisError(a.natural_name, "join")
+                                                  
         variable_names &= set(d.variable_names)
         channel_names &= set(d.channel_names)
     variable_names = list(variable_names)
@@ -111,13 +107,8 @@ def join(
     for a in datas[0].axes:
         if len(a.variables) > 1:
             raise wt_exceptions.ValueError("Applied transform must have single variable axes")
-        if len(np.squeeze(a.variables[0][:]).shape) > 1:
-            raise wt_exceptions.ValueError("Axis '" + a.natural_name + "' of datas[" + 
-                                            str(datas.index(d)) +"] ('" + d.natural_name+
-                                            "') must be 1D, but currently has " + 
-                                            str(len(np.squeeze(a.variables[0][:]).shape)) +
-                                            ' nontrivial axes'
-                                            ) 
+        if a.variables[0][:].squeeze().ndim > 1:
+            raise wt_exceptions.MultidimensionalAxisError(a.natural_name, "join")
         for v in a.variables:
             axis_variable_names.append(v.natural_name)
             axis_variable_units.append(v.units)

--- a/WrightTools/data/_join.py
+++ b/WrightTools/data/_join.py
@@ -88,6 +88,14 @@ def join(
     for d in datas[1:]:
         if d.axis_expressions != axis_expressions:
             raise wt_exceptions.ValueError("Joined data must have same axis_expressions")
+        for a in d.axes:
+            if len(np.squeeze(a.variables[0][:]).shape) > 1:
+                raise wt_exceptions.ValueError("Axis '" + a.natural_name + "' of datas[" + 
+                                                str(datas.index(d)) +"] ('" + d.natural_name+
+                                                "') must be 1D, but currently has " + 
+                                                str(len(np.squeeze(a.variables[0][:]).shape)) +
+                                                ' nontrivial axes'
+                                                )  
         variable_names &= set(d.variable_names)
         channel_names &= set(d.channel_names)
     variable_names = list(variable_names)
@@ -103,6 +111,13 @@ def join(
     for a in datas[0].axes:
         if len(a.variables) > 1:
             raise wt_exceptions.ValueError("Applied transform must have single variable axes")
+        if len(np.squeeze(a.variables[0][:]).shape) > 1:
+            raise wt_exceptions.ValueError("Axis '" + a.natural_name + "' of datas[" + 
+                                            str(datas.index(d)) +"] ('" + d.natural_name+
+                                            "') must be 1D, but currently has " + 
+                                            str(len(np.squeeze(a.variables[0][:]).shape)) +
+                                            ' nontrivial axes'
+                                            ) 
         for v in a.variables:
             axis_variable_names.append(v.natural_name)
             axis_variable_units.append(v.units)

--- a/WrightTools/data/_join.py
+++ b/WrightTools/data/_join.py
@@ -91,7 +91,7 @@ def join(
         for a in d.axes:
             if a.variables[0][:].squeeze().ndim > 1:
                 raise wt_exceptions.MultidimensionalAxisError(a.natural_name, "join")
-                                                  
+
         variable_names &= set(d.variable_names)
         channel_names &= set(d.channel_names)
     variable_names = list(variable_names)


### PR DESCRIPTION
## Changes
Added error message for multidimensional axes. I put the dimensionality check on all axes of all data objects, as opposed to just one data object. We do already enforce that all data objects to be joined have the same axes expressions, but perhaps one could make a mistake in shaping one but not all user-defined 1D versions of variable axes, and still name them all the same thing. 

## Checklist

- [ ] added tests, if applicable
- [ ] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

