### PR TITLE
1110 join single point error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ## Changed
+- Fixed join method to work with data of shape (1,)
 - `Axis`: space character ("\s") in expressions are culled.
 - fixed `interact2D` bug: channel/axes can now be specified with non-zero index arguments
 

--- a/WrightTools/data/_join.py
+++ b/WrightTools/data/_join.py
@@ -247,6 +247,7 @@ def join(
                 slice_.append(slice(None))
             # If p is scalar, a new axis must be added, no transpose needed
             else:
+                transpose.append(np.argmax(data[variable_name].shape))
                 slice_.append(np.newaxis)
             # Triple subscripting needed because newaxis only applys to numpy array
             # New axis added so that subtracting p will broadcast


### PR DESCRIPTION
## Changes
Allowing join to succeed with data of shape (1,). Previously failed due to specific handling of data where np.ndim(data.variable) = 0. See issue #1110 for more info and the example failure case. Unsure of the motivation behind this specific handling of (1,) shape data, but this fix makes the join method work as expected.

## Checklist

- [ ] added tests, if applicable
- [ ] updated documentation, if applicable
- [ ] updated CHANGELOG.md
- [ ] tests pass

