### PR TITLE
Numpy deprecated np.float as an alias for float, use np.float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## Changed
+### Fixed
+- numpy deprecated the `np.float` alias, so use `np.float64` to be more precise
+
+### Changed
 - `Axis`: space character ("\s") in expressions are culled.
 - fixed `interact2D` bug: channel/axes can now be specified with non-zero index arguments
 

--- a/WrightTools/artists/_helpers.py
+++ b/WrightTools/artists/_helpers.py
@@ -355,7 +355,7 @@ def create_figure(
         return (total / (n + mpl * (n - 1))) * mpl
 
     # calculate column widths, width_ratio
-    subplot_ratios = np.array([i for i in cols if not i == "cbar"], dtype=np.float)
+    subplot_ratios = np.array([i for i in cols if not i == "cbar"], dtype=np.float64)
     subplot_ratios /= sum(subplot_ratios)
     subplot_widths = total_subplot_width * subplot_ratios
     width_ratios = []

--- a/WrightTools/data/_pycmds.py
+++ b/WrightTools/data/_pycmds.py
@@ -263,7 +263,7 @@ def _no_collapse_fill(data, headers, file_, shape, verbose):
     file_.seek(0)
     arr = np.genfromtxt(file_, max_rows=frame_size)
     while arr.size > 0:
-        index = tuple(arr[0, 0 : len(shape) - 1].astype(np.int))
+        index = tuple(arr[0, 0 : len(shape) - 1].astype(np.int64))
         if verbose:
             print(index)
         for i, (kind, name) in enumerate(zip(headers["kind"], headers["name"])):

--- a/tests/dataset/ipow.py
+++ b/tests/dataset/ipow.py
@@ -21,7 +21,7 @@ def test_d1_d2():
     value = random.randint(0, 5)
     original_max = data.ai0.max()
     data.ai0 **= value
-    assert data.ai0.max() == original_max**value
+    assert np.isclose(data.ai0.max(), original_max**value)
     data.close()
 
 
@@ -41,7 +41,7 @@ def test_w1():
     value = random.randint(0, 5)
     original_max = data.signal.max()
     data.signal **= value
-    assert data.signal.max() == original_max**value
+    assert np.isclose(data.signal.max(), original_max**value)
     data.close()
 
 


### PR DESCRIPTION
## Changes

please describe your changes here :smiley:

## Checklist

- [ ] added tests, if applicable
- [ ] updated documentation, if applicable
- [ ] updated CHANGELOG.md
- [ ] tests pass

