### PR TITLE
Fix deprecated matplotlib signature

### DIFF
--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -270,7 +270,7 @@ def interact2D(
         ylabel=yaxis.label,
         xlabel=xaxis.label,
     )
-    ax0.grid(b=True)
+    ax0.grid(True)
     # colorbar
     ticks = norm_to_ticks(norm)
     ticklabels = gen_ticklabels(ticks, channel.signed)


### PR DESCRIPTION
the variable name for `grid` was changed from `b` to `visible`, but passing positionally works for both older and newer mpl.

(renamed in mpl 3.5, usage of `b` expired in mpl 3.7)

## Changes

please describe your changes here :smiley:

## Checklist

- [ ] added tests, if applicable
- [ ] updated documentation, if applicable
- [ ] updated CHANGELOG.md
- [ ] tests pass

