### PR TITLE
interact2D small feature update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - numpy deprecated the `np.float` alias, so use `np.float64` to be more precise
 - artists support matplotlib >= 3.7
-- interact2D: fixed bug sliders did not change appearance on focus
+- interact2D: fixed bug where sliders did not change appearance on focus
 
 ### Changed
 - data.join now has MultidimensionalAxisError exception message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - data.join now has MultidimensionalAxisError exception message
 - `Axis`: space character ("\s") in expressions are culled.
 - fixed `interact2D` bug: channel/axes can now be specified with non-zero index arguments
+- `interact2D`: side plots project the extremes along each axis, rather than the mean.
 
 ### Added
+- `interact2D` has informative figure window names
 - `Data.translate_to_txt`: serialize channels and variables and write as a text file.
 
 ## [3.4.6]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - numpy deprecated the `np.float` alias, so use `np.float64` to be more precise
 - artists support matplotlib >= 3.7
+- interact2D: fixed bug sliders did not change appearance on focus
 
 ### Changed
 - data.join now has MultidimensionalAxisError exception message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - numpy deprecated the `np.float` alias, so use `np.float64` to be more precise
 - artists support matplotlib >= 3.7
-- interact2D: fixed bug where sliders did not change appearance on focus
+- `interact2D`: fixed bug where sliders did not change appearance on focus
+- `interact2D`: fixed buggy side plots windowing
 
 ### Changed
-- data.join now has MultidimensionalAxisError exception message
+- `Data.join` now has MultidimensionalAxisError exception message
 - `Axis`: space character ("\s") in expressions are culled.
 - fixed `interact2D` bug: channel/axes can now be specified with non-zero index arguments
-- `interact2D`: side plots project the extremes along each axis, rather than the mean.
+- `interact2D`: side plots project the extremes along each axis, rather than the average.
 
 ### Added
 - `interact2D` has informative figure window names
@@ -23,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [3.4.6]
 
 ### Fixed
-
 - `Data.chop` : fixed bug where chop did not succeed if axes did not span data ndim
 
 ## [3.4.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - numpy deprecated the `np.float` alias, so use `np.float64` to be more precise
+- artists support matplotlib >= 3.7
 
 ### Changed
 - data.join now has MultidimensionalAxisError exception message

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -258,7 +258,15 @@ def interact2D(
             if axis.size > np.prod(axis.shape):
                 raise NotImplementedError("Cannot use multivariable axis as a slider")
             slider_axes = plt.subplot(gs[~len(sliders), :]).axes
-            slider = Slider(slider_axes, axis.label, 0, axis.points.size - 1, valinit=0, valstep=1, track_color="lightgrey")            
+            slider = Slider(
+                slider_axes,
+                axis.label,
+                0,
+                axis.points.size - 1,
+                valinit=0,
+                valstep=1,
+                track_color="lightgrey",
+            )
             sliders[axis.natural_name] = slider
             slider_axes.set_gid(axis.natural_name)
             # axis_to_slider[slider_axes.]

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -363,7 +363,6 @@ def interact2D(
         else:
             if current_state.bin_vs_x:
                 x_proj = np.nanmax(arr, axis=yind)
-                # x_proj = current_state.norm(x_proj)
                 try:
                     sp_x.fill_between(xaxis.points, norm(x_proj), 0, color="k", alpha=0.3)
                 except ValueError:
@@ -371,7 +370,6 @@ def interact2D(
                     sp_x.set_visible(False)
             if current_state.bin_vs_y:
                 y_proj = np.nanmax(arr, axis=xind)
-                # y_proj = current_state.norm(y_proj)
                 try:
                     sp_y.fill_betweenx(yaxis.points, norm(y_proj), 0, color="k", alpha=0.3)
                 except ValueError:

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -218,6 +218,7 @@ def interact2D(
         raise DimensionalityError(">= 2", data.ndim)
     # TODO: implement aspect; doesn't work currently because of our incorporation of colorbar
     fig, gs = create_figure(width="single", nrows=7 + nsliders, cols=[1, 1, 1, 1, 1, "cbar"])
+    plt.get_current_fig_manager().set_window_title(f"interact2D: {data.natural_name}")
     # create axes
     ax0 = plt.subplot(gs[1:6, 0:5])
     ax0.patch.set_facecolor("w")
@@ -382,8 +383,8 @@ def interact2D(
     ax0.set_xlim(xaxis.points.min(), xaxis.points.max())
     ax0.set_ylim(yaxis.points.min(), yaxis.points.max())
 
-    sp_x.set_ylim(-0.05, 1.05)
-    sp_y.set_xlim(-0.05, 1.05)
+    sp_x.set_ylim(0, 1)
+    sp_y.set_xlim(0, 1)
 
     def update_sideplot_slices():
         # TODO:  if bins is only available along one axis, slicing should be valid along the other
@@ -423,6 +424,9 @@ def interact2D(
         obj2D.set_norm(current_state.norm.norm)
         ticklabels = gen_ticklabels(current_state.norm.ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
+
+        update_sideplots(sp_x, sp_y, line_sp_x, line_sp_y)
+
         fig.canvas.draw_idle()
 
     def update_slider(info, use_imshow=use_imshow):
@@ -456,6 +460,10 @@ def interact2D(
         ticklabels = gen_ticklabels(ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
 
+        update_sideplots(sp_x, sp_y, line_sp_x, line_sp_y)
+        fig.canvas.draw_idle()
+
+    def update_sideplots(sp_x, sp_y, line_sp_x, line_sp_y):
         [item.remove() for item in sp_x.collections]
         [item.remove() for item in sp_y.collections]
         if len(sp_x.collections) > 0:  # mpl < 3.7
@@ -465,7 +473,6 @@ def interact2D(
         draw_sideplot_projections()
         if line_sp_x.get_visible() and line_sp_y.get_visible():
             update_sideplot_slices()
-        fig.canvas.draw_idle()
 
     def update_crosshairs(xarg, yarg, hide=False):
         # find closest x and y pts in dataset

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -228,13 +228,11 @@ def interact2D(
     current_state.bin_vs_y = True
     # create buttons
     current_state.local = local
-    radio = RadioButtons(ax_local, (" global", " local"))
+    radio = RadioButtons(ax_local, (" global", " local"), radio_props={"s": 100})
     if local:
         radio.set_active(1)
     else:
         radio.set_active(0)
-    for circle in radio.circles:
-        circle.set_radius(0.14)
     # create sliders
     sliders = {}
     for axis in data.axes:
@@ -436,8 +434,9 @@ def interact2D(
         ticks = norm_to_ticks(norm)
         ticklabels = gen_ticklabels(ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
-        sp_x.collections.clear()
-        sp_y.collections.clear()
+
+        sp_x.clear() # collections.cla()
+        sp_y.clear() # .collections.cla()
         draw_sideplot_projections()
         if line_sp_x.get_visible() and line_sp_y.get_visible():
             update_sideplot_slices()

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -103,34 +103,45 @@ def get_colormap(signed):
     return cmap
 
 
-def get_norm(channel, current_state) -> object:
-    if channel.signed:
-        if not current_state.local:
-            norm = mpl.colors.CenteredNorm(vcenter=channel.null, halfrange=channel.mag())
-        else:
-            norm = mpl.colors.CenteredNorm(vcenter=channel.null)
-            norm.autoscale_None(current_state.dat[channel.natural_name][:])
-        if norm.halfrange == 0:
-            norm.halfrange = 1
-    else:
-        if not current_state.local:
-            norm = mpl.colors.Normalize(vmin=channel.null, vmax=channel.max())
-        else:
-            norm = mpl.colors.Normalize(vmin=channel.null)
-            norm.autoscale_None(current_state.dat[channel.natural_name][:])
-        if norm.vmax == norm.vmin:
-            norm.vmax += 1
-    return norm
+class Norm:
+    def __init__(self, channel, current_state):
+        self.current_state = current_state
+        self.signed = channel.signed
+        self.update(channel)
 
+    def __call__(self, data):
+        out = self.norm(data)
+        return out
 
-def norm_to_ticks(norm) -> np.array:
-    if type(norm) == mpl.colors.CenteredNorm:
-        vmin = norm.vcenter - norm.halfrange
-        vmax = norm.vcenter + norm.halfrange
-    else:  # mpl.colors.Normalize
-        vmin = norm.vmin
-        vmax = norm.vmax
-    return np.linspace(vmin, vmax, 11)
+    def update(self, channel):
+        if self.signed:
+            if not self.current_state.local:
+                norm = mpl.colors.CenteredNorm(vcenter=channel.null, halfrange=channel.mag())
+            else:
+                print("local")
+                norm = mpl.colors.CenteredNorm(vcenter=channel.null)
+                norm.autoscale_None(np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:]))
+            if norm.halfrange == 0:
+                norm.halfrange = 1
+        else:
+            if not self.current_state.local:
+                norm = mpl.colors.Normalize(vmin=channel.null, vmax=np.nanmax(channel[:]))
+            else:
+                norm = mpl.colors.Normalize(vmin=channel.null)
+                norm.autoscale_None(np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:]))
+            if norm.vmax == norm.vmin:
+                norm.vmax += 1
+        self.norm = norm
+
+    @property
+    def ticks(self) -> np.array:
+        if type(self.norm) == mpl.colors.CenteredNorm:
+            vmin = self.norm.vcenter - self.norm.halfrange
+            vmax = self.norm.vcenter + self.norm.halfrange
+        else:  # mpl.colors.Normalize
+            vmin = self.norm.vmin
+            vmax = self.norm.vmax
+        return np.linspace(vmin, vmax, 11)
 
 
 def gen_ticklabels(points, signed=None):
@@ -151,16 +162,6 @@ def gen_ticklabels(points, signed=None):
         fmt = "{" + "0:.{0}f".format(ndigits) + "}"
     ticklabels = [fmt.format(round(point, ndigits)) for point in points]
     return ticklabels
-
-
-def norm(arr, signed, ignore_zero=True):
-    if signed:
-        norm = np.nanmax(np.abs(arr))
-    else:
-        norm = np.nanmax(arr)
-    if norm != 0 and ignore_zero:
-        arr /= norm
-    return arr
 
 
 def interact2D(
@@ -253,52 +254,46 @@ def interact2D(
 
     # create sliders
     sliders = {}
-    for axis in data.axes:
-        if axis not in [xaxis, yaxis]:
-            if axis.size > np.prod(axis.shape):
-                raise NotImplementedError("Cannot use multivariable axis as a slider")
-            slider_axes = plt.subplot(gs[~len(sliders), :]).axes
-            slider = Slider(
-                slider_axes,
-                axis.label,
-                0,
-                axis.points.size - 1,
-                valinit=0,
-                valstep=1,
-                track_color="lightgrey",
-            )
-            sliders[axis.natural_name] = slider
-            slider_axes.set_gid(axis.natural_name)
-            # axis_to_slider[slider_axes.]
-            slider.ax.vlines(
-                range(axis.points.size - 1),
-                *slider.ax.get_ylim(),
-                colors="k",
-                linestyle=":",
-                alpha=0.5,
-            )
-            slider.valtext.set_text(gen_ticklabels(axis.points)[0])
+    for axis in filter(lambda a: a not in [xaxis, yaxis], data.axes):
+        if axis.size > np.prod(axis.shape):
+            raise NotImplementedError("Cannot use multivariable axis as a slider")
+        slider_axes = plt.subplot(gs[~len(sliders), :]).axes
+        slider = Slider(
+            slider_axes,
+            axis.label,
+            0,
+            axis.points.size - 1,
+            valinit=0,
+            valstep=1,
+            track_color="lightgrey",
+        )
+        sliders[axis.natural_name] = slider
+        slider_axes.set_gid(axis.natural_name)
+        slider.ax.vlines(
+            range(axis.points.size - 1),
+            *slider.ax.get_ylim(),
+            colors="k",
+            linestyle=":",
+            alpha=0.5,
+        )
+        slider.valtext.set_text(gen_ticklabels(axis.points)[0])
     current_state.focus = Focus([ax0] + [slider.ax for slider in sliders.values()], sliders)
     # initial xyz start are from zero indices of additional axes
-    current_state.dat = data.chop(
-        xaxis.natural_name,
-        yaxis.natural_name,
-        at=_at_dict(data, sliders, xaxis, yaxis),
-        verbose=False,
-    )[0]
-    norm = get_norm(channel, current_state)
+    current_state.dat = data.at(**_at_dict(data, sliders, xaxis, yaxis))
+    current_state.dat.transform(xaxis.expression, yaxis.expression)
+    current_state.norm = Norm(channel, current_state)
 
     gen_mesh = ax0.pcolormesh if not use_imshow else ax0.imshow
     obj2D = gen_mesh(
         current_state.dat,
         cmap=cmap,
-        norm=norm,
+        norm=current_state.norm.norm,
         ylabel=yaxis.label,
         xlabel=xaxis.label,
     )
     ax0.grid(True)
     # colorbar
-    ticks = norm_to_ticks(norm)
+    ticks = current_state.norm.ticks
     ticklabels = gen_ticklabels(ticks, channel.signed)
     colorbar = plot_colorbar(cax, cmap=cmap, label=channel.natural_name, ticks=ticks)
     colorbar.set_ticklabels(ticklabels)
@@ -339,36 +334,28 @@ def interact2D(
             alpha = 0.4
             blue = "#517799"  # start with #87C7FF and change saturation
             red = "#994C4C"  # start with #FF7F7F and change saturation
+            norm = current_state.norm
+
             if current_state.bin_vs_x:
-                x_proj_norm = max(np.nanmax(x_proj_pos), np.nanmax(-x_proj_neg))
-                if x_proj_norm != 0:
-                    x_proj_pos /= x_proj_norm
-                    x_proj_neg /= x_proj_norm
-                    x_proj /= x_proj_norm
                 try:
-                    sp_x.fill_between(xaxis.points, x_proj_pos, 0, color=red, alpha=alpha)
-                    sp_x.fill_between(xaxis.points, 0, x_proj_neg, color=blue, alpha=alpha)
-                    sp_x.fill_between(xaxis.points, x_proj, 0, color="k", alpha=0.3)
+                    sp_x.fill_between(xaxis.points, norm(x_proj_pos), 0.5, color=red, alpha=alpha)
+                    sp_x.fill_between(xaxis.points, 0.5, norm(x_proj_neg), color=blue, alpha=alpha)
+                    sp_x.fill_between(xaxis.points, norm(x_proj), 0.5, color="k", alpha=0.3)
                 except ValueError:  # Input passed into argument is not 1-dimensional
                     current_state.bin_vs_x = False
                     sp_x.set_visible(False)
             if current_state.bin_vs_y:
-                y_proj_norm = max(np.nanmax(y_proj_pos), np.nanmax(-y_proj_neg))
-                if y_proj_norm != 0:
-                    y_proj_pos /= y_proj_norm
-                    y_proj_neg /= y_proj_norm
-                    y_proj /= y_proj_norm
                 try:
-                    sp_y.fill_betweenx(yaxis.points, y_proj_pos, 0, color=red, alpha=alpha)
-                    sp_y.fill_betweenx(yaxis.points, 0, y_proj_neg, color=blue, alpha=alpha)
-                    sp_y.fill_betweenx(yaxis.points, y_proj, 0, color="k", alpha=0.3)
+                    sp_y.fill_betweenx(yaxis.points, norm(y_proj_pos), 0.5, color=red, alpha=alpha)
+                    sp_y.fill_betweenx(yaxis.points, 0.5, norm(y_proj_neg), color=blue, alpha=alpha)
+                    sp_y.fill_betweenx(yaxis.points, norm(y_proj), 0.5, color="k", alpha=0.3)
                 except ValueError:
                     current_state.bin_vs_y = False
                     sp_y.set_visible(False)
         else:
             if current_state.bin_vs_x:
                 x_proj = np.nanmean(arr, axis=yind)
-                x_proj = norm(x_proj, channel.signed)
+                x_proj = current_state.norm(x_proj)
                 try:
                     sp_x.fill_between(xaxis.points, x_proj, 0, color="k", alpha=0.3)
                 except ValueError:
@@ -376,7 +363,7 @@ def interact2D(
                     sp_x.set_visible(False)
             if current_state.bin_vs_y:
                 y_proj = np.nanmean(arr, axis=xind)
-                y_proj = norm(y_proj, channel.signed)
+                y_proj = current_state.norm(y_proj)
                 try:
                     sp_y.fill_betweenx(yaxis.points, y_proj, 0, color="k", alpha=0.3)
                 except ValueError:
@@ -388,12 +375,9 @@ def interact2D(
     ax0.set_xlim(xaxis.points.min(), xaxis.points.max())
     ax0.set_ylim(yaxis.points.min(), yaxis.points.max())
 
-    if channel.signed:
-        sp_x.set_ylim(-1.1, 1.1)
-        sp_y.set_xlim(-1.1, 1.1)
-    else:
-        sp_x.set_ylim(0, 1.1)
-        sp_y.set_xlim(0, 1.1)
+
+    sp_x.set_ylim(-0.05, 1.05)
+    sp_y.set_xlim(-0.05, 1.05)
 
     def update_sideplot_slices():
         # TODO:  if bins is only available along one axis, slicing should be valid along the other
@@ -411,17 +395,17 @@ def interact2D(
 
         at_dict = _at_dict(data, sliders, xaxis, yaxis)
         at_dict[xaxis.natural_name] = (x0, xaxis.units)
-        side_plot_data = data.chop(yaxis.natural_name, at=at_dict, verbose=False)
-        side_plot = side_plot_data[0][channel.natural_name].points
-        side_plot = norm(side_plot, channel.signed)
+        side_plot_data = data.at(**at_dict)
+        side_plot = side_plot_data[channel.natural_name].points
+        side_plot = current_state.norm(side_plot)
         line_sp_y.set_data(side_plot, yaxis.points)
         side_plot_data.close()
 
         at_dict = _at_dict(data, sliders, xaxis, yaxis)
         at_dict[yaxis.natural_name] = (y0, yaxis.units)
-        side_plot_data = data.chop(xaxis.natural_name, at=at_dict, verbose=False)
-        side_plot = side_plot_data[0][channel.natural_name].points
-        side_plot = norm(side_plot, channel.signed)
+        side_plot_data = data.at(**at_dict)
+        side_plot = side_plot_data[channel.natural_name].points
+        side_plot = current_state.norm(side_plot)
         line_sp_x.set_data(xaxis.points, side_plot)
         side_plot_data.close()
 
@@ -429,9 +413,9 @@ def interact2D(
         if verbose:
             print("normalization:", index)
         current_state.local = radio.value_selected[1:] == "local"
-        norm = get_norm(channel, current_state)
-        obj2D.set_norm(norm)
-        ticklabels = gen_ticklabels(np.linspace(norm.vmin, norm.vmax, 11), channel.signed)
+        current_state.norm.update(channel)
+        obj2D.set_norm(current_state.norm.norm)
+        ticklabels = gen_ticklabels(current_state.norm.ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
         fig.canvas.draw_idle()
 
@@ -459,22 +443,18 @@ def interact2D(
             obj2D.set_data(current_state.dat[channel.natural_name][:].transpose(transpose))
         else:
             obj2D.set_array(current_state.dat[channel.natural_name][:].ravel())
-        norm = get_norm(channel, current_state)
-        obj2D.set_norm(norm)
+        current_state.norm.update(channel)
+        obj2D.set_norm(current_state.norm.norm)
 
-        ticks = norm_to_ticks(norm)
+        ticks = current_state.norm.ticks
         ticklabels = gen_ticklabels(ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
 
         [item.remove() for item in sp_x.collections]
         [item.remove() for item in sp_y.collections]
-
-        if channel.signed:
-            sp_x.set_ylim(-1.1, 1.1)
-            sp_y.set_xlim(-1.1, 1.1)
-        else:
-            sp_x.set_ylim(0, 1.1)
-            sp_y.set_xlim(0, 1.1)
+        if len(sp_x.collections) >  0:  # mpl < 3.7
+            sp_x.collections.clear()
+            sp_y.collections.clear()
 
         draw_sideplot_projections()
         if line_sp_x.get_visible() and line_sp_y.get_visible():
@@ -482,8 +462,6 @@ def interact2D(
         fig.canvas.draw_idle()
 
     def update_crosshairs(xarg, yarg, hide=False):
-        # if x0 is None or y0 is None:
-        #    raise TypeError((x0, y0))
         # find closest x and y pts in dataset
         current_state.xarg = xarg
         current_state.yarg = yarg

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -118,7 +118,6 @@ class Norm:
             if not self.current_state.local:
                 norm = mpl.colors.CenteredNorm(vcenter=channel.null, halfrange=channel.mag())
             else:
-                print("local")
                 norm = mpl.colors.CenteredNorm(vcenter=channel.null)
                 norm.autoscale_None(
                     np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:])
@@ -321,16 +320,19 @@ def interact2D(
             )
             > 1
         ).index(True)
+
+        norm = current_state.norm
+
         if channel.signed:
             temp_arr = np.ma.masked_array(arr, np.isnan(arr), copy=True)
             temp_arr[temp_arr < 0] = 0
-            x_proj_pos = np.nanmean(temp_arr, axis=yind)
-            y_proj_pos = np.nanmean(temp_arr, axis=xind)
+            x_proj_pos = np.nanmax(temp_arr, axis=yind)
+            y_proj_pos = np.nanmax(temp_arr, axis=xind)
 
             temp_arr = np.ma.masked_array(arr, np.isnan(arr), copy=True)
             temp_arr[temp_arr > 0] = 0
-            x_proj_neg = np.nanmean(temp_arr, axis=yind)
-            y_proj_neg = np.nanmean(temp_arr, axis=xind)
+            x_proj_neg = np.nanmin(temp_arr, axis=yind)
+            y_proj_neg = np.nanmin(temp_arr, axis=xind)
 
             x_proj = np.nanmean(arr, axis=yind)
             y_proj = np.nanmean(arr, axis=xind)
@@ -338,7 +340,6 @@ def interact2D(
             alpha = 0.4
             blue = "#517799"  # start with #87C7FF and change saturation
             red = "#994C4C"  # start with #FF7F7F and change saturation
-            norm = current_state.norm
 
             if current_state.bin_vs_x:
                 try:
@@ -360,18 +361,18 @@ def interact2D(
                     sp_y.set_visible(False)
         else:
             if current_state.bin_vs_x:
-                x_proj = np.nanmean(arr, axis=yind)
-                x_proj = current_state.norm(x_proj)
+                x_proj = np.nanmax(arr, axis=yind)
+                # x_proj = current_state.norm(x_proj)
                 try:
-                    sp_x.fill_between(xaxis.points, x_proj, 0, color="k", alpha=0.3)
+                    sp_x.fill_between(xaxis.points, norm(x_proj), 0, color="k", alpha=0.3)
                 except ValueError:
                     current_state.bin_vs_x = False
                     sp_x.set_visible(False)
             if current_state.bin_vs_y:
-                y_proj = np.nanmean(arr, axis=xind)
-                y_proj = current_state.norm(y_proj)
+                y_proj = np.nanmax(arr, axis=xind)
+                # y_proj = current_state.norm(y_proj)
                 try:
-                    sp_y.fill_betweenx(yaxis.points, y_proj, 0, color="k", alpha=0.3)
+                    sp_y.fill_betweenx(yaxis.points, norm(y_proj), 0, color="k", alpha=0.3)
                 except ValueError:
                     current_state.bin_vs_y = False
                     sp_y.set_visible(False)

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -120,7 +120,9 @@ class Norm:
             else:
                 print("local")
                 norm = mpl.colors.CenteredNorm(vcenter=channel.null)
-                norm.autoscale_None(np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:]))
+                norm.autoscale_None(
+                    np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:])
+                )
             if norm.halfrange == 0:
                 norm.halfrange = 1
         else:
@@ -128,7 +130,9 @@ class Norm:
                 norm = mpl.colors.Normalize(vmin=channel.null, vmax=np.nanmax(channel[:]))
             else:
                 norm = mpl.colors.Normalize(vmin=channel.null)
-                norm.autoscale_None(np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:]))
+                norm.autoscale_None(
+                    np.ma.masked_invalid(self.current_state.dat[channel.natural_name][:])
+                )
             if norm.vmax == norm.vmin:
                 norm.vmax += 1
         self.norm = norm
@@ -347,7 +351,9 @@ def interact2D(
             if current_state.bin_vs_y:
                 try:
                     sp_y.fill_betweenx(yaxis.points, norm(y_proj_pos), 0.5, color=red, alpha=alpha)
-                    sp_y.fill_betweenx(yaxis.points, 0.5, norm(y_proj_neg), color=blue, alpha=alpha)
+                    sp_y.fill_betweenx(
+                        yaxis.points, 0.5, norm(y_proj_neg), color=blue, alpha=alpha
+                    )
                     sp_y.fill_betweenx(yaxis.points, norm(y_proj), 0.5, color="k", alpha=0.3)
                 except ValueError:
                     current_state.bin_vs_y = False

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -50,6 +50,20 @@ def _at_dict(data, sliders, xaxis, yaxis):
     }
 
 
+def create_local_global_radio(ax, local):
+    if mpl.__version__ >= "3.7":
+        radio = RadioButtons(ax, (" global", " local"), radio_props={"s": 100})
+    else:
+        radio = RadioButtons(ax, (" global", " local"))
+        for circle in radio.circles:
+            circle.set_radius(0.14)
+    if local:
+        radio.set_active(1)
+    else:
+        radio.set_active(0)
+    return radio
+
+
 def get_axes(data, axes):
     xaxis, yaxis = axes
     if type(xaxis) in [int, str]:
@@ -226,13 +240,11 @@ def interact2D(
     ydir = 1 if yaxis.points.flatten()[-1] - yaxis.points.flatten()[0] > 0 else -1
     current_state.bin_vs_x = True
     current_state.bin_vs_y = True
+
     # create buttons
     current_state.local = local
-    radio = RadioButtons(ax_local, (" global", " local"), radio_props={"s": 100})
-    if local:
-        radio.set_active(1)
-    else:
-        radio.set_active(0)
+    radio = create_local_global_radio(ax_local, local)
+
     # create sliders
     sliders = {}
     for axis in data.axes:
@@ -435,8 +447,8 @@ def interact2D(
         ticklabels = gen_ticklabels(ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
 
-        sp_x.clear()  # collections.cla()
-        sp_y.clear()  # .collections.cla()
+        sp_x.clear()
+        sp_y.clear()
         draw_sideplot_projections()
         if line_sp_x.get_visible() and line_sp_y.get_visible():
             update_sideplot_slices()

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -435,8 +435,8 @@ def interact2D(
         ticklabels = gen_ticklabels(ticks, channel.signed)
         colorbar.set_ticklabels(ticklabels)
 
-        sp_x.clear() # collections.cla()
-        sp_y.clear() # .collections.cla()
+        sp_x.clear()  # collections.cla()
+        sp_y.clear()  # .collections.cla()
         draw_sideplot_projections()
         if line_sp_x.get_visible() and line_sp_y.get_visible():
             update_sideplot_slices()

--- a/WrightTools/artists/_interact.py
+++ b/WrightTools/artists/_interact.py
@@ -57,7 +57,7 @@ def _at_dict(data, sliders, xaxis, yaxis):
 
 
 def create_local_global_radio(ax, local):
-    if mpl.__version__ >= "3.7":
+    if mpl.__version_info__ >= (3, 7):
         radio = RadioButtons(ax, (" global", " local"), radio_props={"s": 100})
     else:
         radio = RadioButtons(ax, (" global", " local"))

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         "h5py",
         "imageio",
-        "matplotlib>=3.4.0",
+        "matplotlib>=3.7.0",
         "numexpr",
         "numpy>=1.15.0",
         "pint",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         "h5py",
         "imageio",
-        "matplotlib>=3.7.0",
+        "matplotlib>=3.4.0",
         "numexpr",
         "numpy>=1.15.0",
         "pint",

--- a/tests/artists/test_interact2D.py
+++ b/tests/artists/test_interact2D.py
@@ -15,7 +15,7 @@ def test_perovskite():
             break
         except:
             pass
-    wt.artists.interact2D(data, xaxis=2, yaxis=1)
+    return wt.artists.interact2D(data, xaxis=2, yaxis=1)
 
 
 def test_MoS2():
@@ -23,7 +23,7 @@ def test_MoS2():
     data = wt.open(p)
     data.convert("eV")
     data.level(0, 2, -4)
-    wt.artists.interact2D(data, xaxis=0, yaxis=1, local=True)
+    return wt.artists.interact2D(data, xaxis=0, yaxis=1, local=True)
 
 
 def test_asymmetric():
@@ -82,16 +82,16 @@ def test_4D():
     data.create_variable("d_1", values=tau[None, None, None, :], units="ps")
 
     data.transform("w_1", "w_2", "w_3", "d_1")
-    wt.artists.interact2D(data, xaxis=0, yaxis=1, local=True)
+    return wt.artists.interact2D(data, xaxis=0, yaxis=1, local=True)
 
 
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
     plt.close("all")
-    test_perovskite()
-    test_MoS2()
-    test_asymmetric()
-    test_skewed()
-    test_4D()
+    out1 = test_perovskite()
+    out2 = test_MoS2()
+    # test_asymmetric()
+    # test_skewed()
+    # out = test_4D()
     plt.show()

--- a/tests/artists/test_interact2D.py
+++ b/tests/artists/test_interact2D.py
@@ -76,12 +76,12 @@ def test_4D():
 
     data = wt.data.Data(name="data")
     data.create_channel("signal", values=signal, signed=True)
-    data.create_variable("w1", values=w1[:, None, None, None], units="wn")
-    data.create_variable("w2", values=w2[None, :, None, None], units="wn")
-    data.create_variable("w3", values=w3[None, None, :, None], units="wn")
-    data.create_variable("d1", values=tau[None, None, None, :], units="ps")
+    data.create_variable("w_1", values=w1[:, None, None, None], units="wn")
+    data.create_variable("w_2", values=w2[None, :, None, None], units="wn")
+    data.create_variable("w_3", values=w3[None, None, :, None], units="wn")
+    data.create_variable("d_1", values=tau[None, None, None, :], units="ps")
 
-    data.transform("w1", "w2", "w3", "d1")
+    data.transform("w_1", "w_2", "w_3", "d_1")
     wt.artists.interact2D(data, xaxis=0, yaxis=1, local=True)
 
 

--- a/tests/artists/test_interact2D.py
+++ b/tests/artists/test_interact2D.py
@@ -37,7 +37,7 @@ def test_asymmetric():
     data.create_variable("x", values=x[:, None], units="wn")
     data.create_variable("y", values=y[None, :], units="wn")
     data.transform("x", "y")
-    wt.artists.interact2D(data, xaxis=1, yaxis=0)
+    return wt.artists.interact2D(data, xaxis=1, yaxis=0)
 
 
 def test_skewed():
@@ -46,7 +46,7 @@ def test_skewed():
     data = wt.data.from_PyCMDS(p)
     data.convert("wn", convert_variables=True)
     data.transform("wm", "w1")  # wm = w1 + 2*w2
-    wt.artists.interact2D(data, xaxis=0, yaxis=1)
+    return wt.artists.interact2D(data, xaxis=0, yaxis=1)
 
 
 def test_4D():
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     plt.close("all")
     out1 = test_perovskite()
     out2 = test_MoS2()
-    # test_asymmetric()
-    # test_skewed()
-    # out = test_4D()
+    out3 = test_asymmetric()
+    out4 = test_skewed()
+    out5 = test_4D()
     plt.show()


### PR DESCRIPTION
## Changes

* figure windows now have non-generic names ("Figure1" -> "interact2D {data name}")
* sideplot projections show the data extremes (min and max), rather than the mean.
* normalization of 2D map and side plot limits are now use the same code references (the `Norm` class)
* refactored interact2D to remove some of the 🍝 (just some).  

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

