### PR TITLE
numpy 2.0 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - constants in chopped data will inherit the units of the original data
 
 ## Changed
+- numpy 2.0 compatible
 - refactor of artists.quick1D and artists.quick2D
 - quick2D and quick1D will not force `autosave=True` if the number of figures is large.  Instead, interactive plotting will be truncated if the number of figures is large.
 - artists now gets turbo colormap straight from matplotlib

--- a/WrightTools/_open.py
+++ b/WrightTools/_open.py
@@ -13,6 +13,7 @@ import numpy as np
 from . import collection as wt_collection
 from . import data as wt_data
 from . import _group as wt_group
+from numpy.lib.npyio import DataSource
 
 
 # --- define -------------------------------------------------------------------------------------
@@ -45,7 +46,7 @@ def open(filepath, edit_local=False):
         Root-level object in file.
     """
     filepath = os.fspath(filepath)
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     if edit_local is False:
         tf = tempfile.mkstemp(prefix="", suffix=".wt5")
         with _open(tf[1], "w+b") as tff:

--- a/WrightTools/collection/_cary.py
+++ b/WrightTools/collection/_cary.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from .. import exceptions as wt_exceptions
 from ._collection import Collection
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -64,7 +65,7 @@ def from_Cary(filepath, name=None, parent=None, verbose=True):
         name = "cary"
     # import array
     lines = []
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     with ds.open(filestr, "rt", encoding="iso-8859-1") as f:
         header = f.readline()
         columns = f.readline()

--- a/WrightTools/data/_aramis.py
+++ b/WrightTools/data/_aramis.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -51,7 +52,7 @@ def from_Aramis(filepath, name=None, parent=None, verbose=True) -> Data:
 
     if not ".ngc" in filepath.suffixes:
         wt_exceptions.WrongFileTypeWarning.warn(filepath, ".ngc")
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rb")
     header = f.readline()
     if header != b"NGSNextGen\x01\x00\x00\x00\x01\x00\x00\x00\n":

--- a/WrightTools/data/_brunold.py
+++ b/WrightTools/data/_brunold.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -61,7 +62,7 @@ def from_BrunoldrRaman(filepath, name=None, parent=None, verbose=True) -> Data:
     else:
         data = parent.create_data(**kwargs)
     # array
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     arr = np.genfromtxt(f, delimiter="\t").T
     f.close()

--- a/WrightTools/data/_colors.py
+++ b/WrightTools/data/_colors.py
@@ -13,6 +13,7 @@ from scipy.interpolate import griddata
 
 from ._data import Data
 from .. import kit as wt_kit
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -66,7 +67,7 @@ def from_COLORS(
     else:
         filestrs = [os.fspath(filepaths)]
         filepaths = [pathlib.Path(filepaths)]
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     # define format of dat file -------------------------------------------------------------------
     if cols:
         pass

--- a/WrightTools/data/_data.py
+++ b/WrightTools/data/_data.py
@@ -852,27 +852,28 @@ class Data(Group):
                 np.sum(np.diff(x, axis=axis_index), axis=axis_index, keepdims=True)
             )
 
+        trapezoid = np.trapezoid if (int(np.__version__.split(".")[0]) > 1) else np.trapz
         for moment in moments:
             about = 0
             norm = 1
             if moment > 0:
-                norm = np.trapz(y, x, axis=axis_index)
+                norm = trapezoid(y, x, axis=axis_index)
                 norm = np.array(norm)
                 norm.shape = new_shape
             if moment > 1:
-                about = np.trapz(x * y, x, axis=axis_index)
+                about = trapezoid(x * y, x, axis=axis_index)
                 about = np.array(about)
                 about.shape = new_shape
                 about /= norm
             if moment > 2:
-                sigma = np.trapz((x - about) ** 2 * y, x, axis=axis_index)
+                sigma = trapezoid((x - about) ** 2 * y, x, axis=axis_index)
                 sigma = np.array(sigma)
                 sigma.shape = new_shape
                 sigma /= norm
                 sigma **= 0.5
                 norm *= sigma**moment
 
-            values = np.trapz((x - about) ** moment * y, x, axis=axis_index)
+            values = trapezoid((x - about) ** moment * y, x, axis=axis_index)
             values = np.array(values)
             values.shape = new_shape
             values /= norm

--- a/WrightTools/data/_jasco.py
+++ b/WrightTools/data/_jasco.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -59,7 +60,7 @@ def from_JASCO(filepath, name=None, parent=None, verbose=True) -> Data:
     else:
         data = parent.create_data(**kwargs)
     # array
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     arr = np.genfromtxt(f, skip_header=18).T
     f.close()

--- a/WrightTools/data/_kent.py
+++ b/WrightTools/data/_kent.py
@@ -14,6 +14,7 @@ from scipy.interpolate import griddata
 
 from ._data import Data
 from .. import kit as wt_kit
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -86,7 +87,7 @@ def from_KENT(
     filestrs = [os.fspath(f) for f in filepaths]
     filepaths = [pathlib.Path(f) for f in filepaths]
     # import full array ---------------------------------------------------------------------------
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     arr = []
     for f in filestrs:
         ff = ds.open(f, "rt")

--- a/WrightTools/data/_labram.py
+++ b/WrightTools/data/_labram.py
@@ -11,6 +11,7 @@ import numpy as np
 from ._data import Data
 from .. import exceptions as wt_exceptions
 from ..kit import _timestamp as timestamp
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -62,7 +63,7 @@ def from_LabRAM(filepath, name=None, parent=None, verbose=True) -> Data:
     else:
         data = parent.create_data(**kwargs)
 
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt", encoding="ISO-8859-1")
 
     # header

--- a/WrightTools/data/_ocean_optics.py
+++ b/WrightTools/data/_ocean_optics.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -61,7 +62,7 @@ def from_ocean_optics(filepath, name=None, *, parent=None, verbose=True) -> Data
     # array
     skip_header = 14
     skip_footer = 1
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     arr = np.genfromtxt(f, skip_header=skip_header, skip_footer=skip_footer, delimiter="\t").T
     f.close()

--- a/WrightTools/data/_pycmds.py
+++ b/WrightTools/data/_pycmds.py
@@ -15,6 +15,7 @@ import tidy_headers
 from ._data import Data
 from .. import kit as wt_kit
 from .. import units as wt_units
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -51,7 +52,7 @@ def from_PyCMDS(filepath, name=None, parent=None, verbose=True, *, collapse=True
     filestr = os.fspath(filepath)
 
     # header
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     file_ = ds.open(filestr, "rt")
     headers = tidy_headers.read(file_)
     file_.seek(0)

--- a/WrightTools/data/_shimadzu.py
+++ b/WrightTools/data/_shimadzu.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -59,7 +60,7 @@ def from_shimadzu(filepath, name=None, parent=None, verbose=True) -> Data:
     else:
         data = parent.create_data(**kwargs)
     # array
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     arr = np.genfromtxt(f, skip_header=2, delimiter=",").T
     f.close()

--- a/WrightTools/data/_solis.py
+++ b/WrightTools/data/_solis.py
@@ -13,6 +13,7 @@ import numpy as np
 from ._data import Data
 from .. import exceptions as wt_exceptions
 from ..kit import _timestamp as timestamp
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -68,7 +69,7 @@ def from_Solis(filepath, name=None, parent=None, verbose=True) -> Data:
     if not name:
         name = filepath.name.split(".")[0]
     # create data
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     axis0 = []
     arr = []

--- a/WrightTools/data/_spcm.py
+++ b/WrightTools/data/_spcm.py
@@ -13,6 +13,7 @@ import numpy as np
 from ._data import Data
 from .. import exceptions as wt_exceptions
 from ..kit import _timestamp as timestamp
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -65,7 +66,7 @@ def from_spcm(filepath, name=None, *, delimiter=",", parent=None, verbose=True) 
     # create headers dictionary
     headers = collections.OrderedDict()
     header_lines = 0
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     while True:
         line = f.readline().strip()

--- a/WrightTools/data/_tensor27.py
+++ b/WrightTools/data/_tensor27.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._data import Data
 from .. import exceptions as wt_exceptions
+from numpy.lib.npyio import DataSource
 
 
 # --- define --------------------------------------------------------------------------------------
@@ -70,7 +71,7 @@ def from_Tensor27(filepath, name=None, parent=None, verbose=True) -> Data:
     else:
         data = parent.create_data(**kwargs)
     # array
-    ds = np.DataSource(None)
+    ds = DataSource(None)
     f = ds.open(filestr, "rt")
     arr = np.genfromtxt(f, skip_header=0).T
     f.close()

--- a/docs/write_from_function.rst
+++ b/docs/write_from_function.rst
@@ -72,7 +72,7 @@ We will walk through by way of example, using :meth:`~WrightTools.data.from_JASC
         else:
             data = parent.create_data(**kwargs)
         # array
-        ds = np.DataSource(None)
+        ds = np.lib.npyio.DataSource(None)
         f = ds.open(filestr, "rt")
         arr = np.genfromtxt(f, skip_header=18).T
         f.close()
@@ -249,7 +249,7 @@ For one-dimensional data formats, this is particularly easy:
 .. code-block:: python
 
         # array
-        ds = np.DataSource(None)
+        ds = np.lib.npyio.DataSource(None)
         f = ds.open(filestr, "rt")
         arr = np.genfromtxt(f, skip_header=18).T
         f.close()
@@ -260,7 +260,7 @@ For one-dimensional data formats, this is particularly easy:
 :class:`numpy.DataSource` is a class which provides transparent decompression and remote file retrieval.
 :func:`numpy.genfromtxt` will handle this itself, however it will leave the downloaded files in the
 working directory, and opening explicitly allows you to use the file more directly as well.
-Using ``np.DataSource(None)`` causes it to use temporary files which are removed automatically.
+Using ``numpy.lib.npyio.DataSource(None)`` causes it to use temporary files which are removed automatically.
 Opening in ``"rt"`` mode ensures that you are reading as text.
 
 Parsing multidimensional datasets (and in particular formats which allow arbitrary dimensionality)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extra_files = {
 with open(os.path.join(here, "WrightTools", "VERSION")) as version_file:
     version = version_file.read().strip()
 
-docs_require = ["sphinx", "sphinx-gallery==0.8.2", "sphinx-rtd-theme"]
+docs_require = ["sphinx<8.0", "sphinx-gallery==0.8.2", "sphinx-rtd-theme"]
 
 setup(
     name="WrightTools",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "python-dateutil",
         "scipy",
         "click",
-        "tidy_headers>=1.0.0",
+        "tidy_headers>=1.0.4",
         "rich",
     ],
     extras_require={

--- a/tests/kit/lineshapes.py
+++ b/tests/kit/lineshapes.py
@@ -6,6 +6,7 @@
 import numpy as np
 
 import WrightTools as wt
+
 # numpy 2.0 compatibility
 trapezoid = np.trapezoid if int(np.__version__.split(".")[0]) > 1 else np.trapz
 

--- a/tests/kit/lineshapes.py
+++ b/tests/kit/lineshapes.py
@@ -6,7 +6,8 @@
 import numpy as np
 
 import WrightTools as wt
-
+# numpy 2.0 compatibility
+trapezoid = np.trapezoid if int(np.__version__.split(".")[0]) > 1 else np.trapz
 
 # --- test ----------------------------------------------------------------------------------------
 
@@ -16,7 +17,7 @@ def test_gaussian():
     x0 = 0
     FWHM = 1
     y = wt.kit.gaussian(x, x0, FWHM, norm="area")
-    assert np.isclose(np.trapz(y, x), 1, rtol=1e-3, atol=1e-3)
+    assert np.isclose(trapezoid(y, x), 1, rtol=1e-3, atol=1e-3)
     y = wt.kit.gaussian(x, x0, FWHM, norm="height")
     assert np.isclose(y.max(), 1, rtol=1e-3, atol=1e-3)
 
@@ -26,7 +27,7 @@ def test_lorentzian_complex():
     x0 = 0
     G = 0.1
     y = wt.kit.lorentzian_complex(x, x0, G, norm="area_int")
-    assert np.isclose(np.trapz(np.abs(y) ** 2, x), 1, rtol=1e-3, atol=1e-3)
+    assert np.isclose(trapezoid(np.abs(y) ** 2, x), 1, rtol=1e-3, atol=1e-3)
     y = wt.kit.lorentzian_complex(x, x0, G, norm="height_imag")
     assert np.isclose(y.imag.max(), 1, rtol=1e-3, atol=1e-3)
 
@@ -36,7 +37,7 @@ def test_lorentzian_real():
     x0 = 0
     G = 0.1
     y = wt.kit.lorentzian_real(x, x0, G, norm="area")
-    assert np.isclose(np.trapz(y, x), 1, rtol=1e-3, atol=1e-3)
+    assert np.isclose(trapezoid(y, x), 1, rtol=1e-3, atol=1e-3)
     y = wt.kit.lorentzian_real(x, x0, G, norm="height")
     assert np.isclose(y.max(), 1, rtol=1e-3, atol=1e-3)
 


### PR DESCRIPTION
Making the transition to support the new API
https://numpy.org/doc/stable/numpy_2_0_migration_guide.html

## Changes

* numpy v2 compliant
* resolves #1186
* pin sphinx<8.0
* addresses #1192 

## Checklist

- [x] updated documentation (update "from" docs, example)
- [x] updated CHANGELOG.md
- [x] tests pass

