### PR TITLE
fix quick2D bugs with contour, contourf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- quick2D can now be called with contours
+
 ## [3.5.5]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
-- quick2D can now be called with contours
+- quick2D works with contours on
+- quick2D works with `pixelated=False` (i.e. contourf)
 
 ## [3.5.5]
 

--- a/WrightTools/artists/_base.py
+++ b/WrightTools/artists/_base.py
@@ -154,7 +154,7 @@ class Axes(matplotlib.axes.Axes):
                 data=data, channel_index=channel_index, dynamic_range=dynamic_range, **kwargs
             )
             if plot_type == "contourf":
-                if "levels" not in kwargs.keys():
+                if "levels" not in kwargs.keys() and "norm" not in kwargs.keys():
                     kwargs["levels"] = np.linspace(kwargs["vmin"], kwargs["vmax"], 256)
             elif plot_type == "contour":
                 if "levels" not in kwargs.keys():

--- a/WrightTools/artists/_quick.py
+++ b/WrightTools/artists/_quick.py
@@ -302,7 +302,7 @@ def _quick2D(
     fname=None,
 ):
 
-    def determine_contour_levels(local_channel, global_channel, contours, local):
+    def determine_contour_levels(local_channel, global_channel, local):
         # force top and bottom contour to be data range then clip them out
         null = local_channel.null
         if local_channel.signed:

--- a/tests/artists/test_quick2D.py
+++ b/tests/artists/test_quick2D.py
@@ -44,6 +44,23 @@ def test_perovskite():
     handler(True)
 
 
+def test_contourf_option():
+    w1 = np.linspace(-2, 2, 51)
+    w2 = np.linspace(-1, 1, 11)
+    w3 = np.linspace(1, 3, 5)
+    signal = np.cos(w1[:, None, None] + w2[None, :, None] + w3[None, None, :])
+    data = wt.data.Data(name="data")
+    data.create_channel("signal", values=signal, signed=True)
+    data.create_variable("w1", values=w1[:, None, None], units="wn", label="1")
+    data.create_variable("w2", values=w2[None, :, None], units="wn", label="2")
+    data.create_variable("w3", values=w3[None, None, :], units="wn", label="3")
+    data.transform("w1", "w2", "w3")
+    data.moment(2, 0, 0)
+    # moments bug(?): moment is not signed, even though the data is
+    handler = wt.artists._quick._quick2D(data, channel=-1, pixelated=False)
+    handler(True)
+
+
 def test_4D():
     w1 = np.linspace(-3, 3, 3)
     w2 = np.linspace(-2, 2, 3)
@@ -89,5 +106,6 @@ if __name__ == "__main__":
     test_save_arguments()
     test_perovskite()
     test_4D()
+    test_contourf_option()
     test_remove_uninvolved_dimensions()
     plt.show()

--- a/tests/artists/test_quick2D.py
+++ b/tests/artists/test_quick2D.py
@@ -62,7 +62,7 @@ def test_4D():
     data.create_variable("w3", values=w3[None, None, :, None], units="wn", label="3")
     data.create_variable("d1", values=tau[None, None, None, :], units="ps")
     data.transform("w1", "w2", "w3", "d1")
-    wt.artists.quick2D(data, xaxis=0, yaxis=1)
+    wt.artists.quick2D(data, xaxis=0, yaxis=1, contours=3)
 
 
 def test_remove_uninvolved_dimensions():


### PR DESCRIPTION
* fix simple arg error that broke quick2D when contours was used
* let quick2D work with pixelated=False
* addresses #1191 

## Checklist

- [x] added tests, if applicable
- [x] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [x] tests pass

