### PR TITLE
setuptools finds correct WrightTools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,4 +68,4 @@ wt5 = "WrightTools.cli._wt5:cli"
 wt-convert = "WrightTools.cli._units:cli"
 
 [tool.setuptools.dynamic]
-version = {file = "VERSION"}
+version = {file = "WrightTools/VERSION"}


### PR DESCRIPTION
`setuptools` was extracting WrightTools version as 0.0.0--now we point to the explicit version. 
Note that we point setuptools to the version file--branch tags never exist as far as setuptools is concerned (which is probably what we want for publishing anyways). 

## Changes

- `pyproject.toml` points to correct version


## Checklist

- [x] tests pass

