### PR TITLE
Update _solis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 - `from_solis`:  Now accepts Date and Time metadata that includes fractional seconds (if still in original format %a %b %d %H:%M:%S %Y), and has error handling for other unexpected Date and Time formats.
-  
+
 ## [3.6.4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
-- `from_solis`:  Now accepts Date and Time metadata that includes fractional seconds (if still in original format %a %b %d %H:%M:%S %Y), and has error handling for other unexpected Date and Time formats.
+- `from_solis`:  incorporates error handling for unexpected formats of Date and Time metadata, and now accepts (and rounds) fractional seconds if in expected format %a %b %d %H:%M:%S %Y
 
 ## [3.6.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
-
+- `from_solis`:  Now accepts Date and Time metadata that includes fractional seconds (if still in original format %a %b %d %H:%M:%S %Y), and has error handling for other unexpected Date and Time formats.
+  
 ## [3.6.4]
 
 ### Added

--- a/WrightTools/data/_solis.py
+++ b/WrightTools/data/_solis.py
@@ -119,23 +119,23 @@ def from_Solis(filepath, name=None, parent=None, verbose=True) -> Data:
         created = attrs["Date and Time"]  # is this UTC?
         created = time.strptime(created, "%a %b %d %H:%M:%S %Y")
         created = timestamp.TimeStamp(time.mktime(created)).RFC3339
-    except ValueError: #round fractional seconds assuming it is the culprit
+    except ValueError:  # round fractional seconds assuming it is the culprit
         try:
-            HMS = created.split(' ')[3].split(':')
+            HMS = created.split(" ")[3].split(":")
             round_seconds = int(round(float(HMS[-1])))
-            HMS_rounded = HMS[0] +':'+ HMS[1] +':'+ str(round_seconds)
+            HMS_rounded = HMS[0] + ":" + HMS[1] + ":" + str(round_seconds)
             created_rounded = []
-            for i,p in enumerate(created.split(' ')):
-                if i>0:
-                    created_rounded.append(' ')
-                if i !=3:
+            for i, p in enumerate(created.split(" ")):
+                if i > 0:
+                    created_rounded.append(" ")
+                if i != 3:
                     created_rounded.append(p)
                 else:
                     created_rounded.append(HMS_rounded)
             created = "".join(created_rounded)
             created = time.strptime(created, "%a %b %d %H:%M:%S %Y")
             created = timestamp.TimeStamp(time.mktime(created)).RFC3339
-        except (ValueError, IndexError) as e: #rounding failed, saving modified time instead:
+        except (ValueError, IndexError) as e:  # rounding failed, saving modified time instead:
             created = os.stat(filepath).st_mtime
             created = timestamp.TimeStamp(created).RFC3339
             warnings.warn(

--- a/WrightTools/data/_solis.py
+++ b/WrightTools/data/_solis.py
@@ -119,6 +119,28 @@ def from_Solis(filepath, name=None, parent=None, verbose=True) -> Data:
         created = attrs["Date and Time"]  # is this UTC?
         created = time.strptime(created, "%a %b %d %H:%M:%S %Y")
         created = timestamp.TimeStamp(time.mktime(created)).RFC3339
+    except ValueError: #round fractional seconds assuming it is the culprit
+        try:
+            HMS = created.split(' ')[3].split(':')
+            round_seconds = int(round(float(HMS[-1])))
+            HMS_rounded = HMS[0] +':'+ HMS[1] +':'+ str(round_seconds)
+            created_rounded = []
+            for i,p in enumerate(created.split(' ')):
+                if i>0:
+                    created_rounded.append(' ')
+                if i !=3:
+                    created_rounded.append(p)
+                else:
+                    created_rounded.append(HMS_rounded)
+            created = "".join(created_rounded)
+            created = time.strptime(created, "%a %b %d %H:%M:%S %Y")
+            created = timestamp.TimeStamp(time.mktime(created)).RFC3339
+        except (ValueError, IndexError) as e: #rounding failed, saving modified time instead:
+            created = os.stat(filepath).st_mtime
+            created = timestamp.TimeStamp(created).RFC3339
+            warnings.warn(
+                f"{filepath.name} has a 'Date and Time' format that does not match %a %b %d %H:%M:%S %Y: using file modified time instead: {created}"
+            )
     except KeyError:  # use file creation time
         created = os.stat(filepath).st_mtime
         created = timestamp.TimeStamp(created).RFC3339


### PR DESCRIPTION
Adds Date Time support for fractional seconds (which my newer Andor camera uses), and a new error handling exception for other unexpected Date Time formats, resolving Issue #1246.
Manually tested that both DateTime formats with fractional seconds and arbitrary formats now still allow for the data to be opened. Welcome any improvements in code quality/efficiency.

## Changes

If Date Time has fractional seconds, we round to nearest integer and save the whole seconds as done previously.
If Date Time is an unexpected format, we provide the warning and save the file modified time instead. 

Manually tested that both DateTime formats with fractional seconds and arbitrary formats now still allow for the data to be opened. 

## Checklist

- [ ] added tests, if applicable
- [ ] updated documentation, if applicable
- [x] updated CHANGELOG.md
- [ ] tests pass

